### PR TITLE
修复应用启动崩溃问题

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.JoyMan">
+            android:theme="@style/Theme.JoyMan.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## 问题描述
JoyMan 应用启动后立即崩溃，错误信息：
```
java.lang.IllegalStateException: This Activity already has an action bar supplied by the window decor.
```

## 根本原因
- `AndroidManifest.xml` 中 MainActivity 使用了 `Theme.JoyMan` 主题（继承自 `DarkActionBar`）
- 代码中又调用了 `setSupportActionBar()` 设置自定义 Toolbar
- 导致 ActionBar 冲突

## 解决方案
将 MainActivity 的主题修改为 `Theme.JoyMan.NoActionBar`，该主题已设置：
- `windowActionBar=false`
- `windowNoTitle=true`

这样就能正确使用自定义 Toolbar，避免冲突。

## 修改内容
- `app/src/main/AndroidManifest.xml`: 修改 MainActivity 主题

## 测试建议
1. 重新编译 APK
2. 安装到设备
3. 验证应用能正常启动并显示主界面

相关任务：Redmine #4307