### PR TITLE
添加数据库定义：AppDatabase Room 数据库类（AppDatabase.java）

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/data/database/AppDatabase.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/data/database/AppDatabase.java
@@ -1,0 +1,152 @@
+package com.stupidbeauty.joyman.data.database;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.room.Database;
+import androidx.room.Room;
+import androidx.room.RoomDatabase;
+import androidx.room.migration.Migration;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+
+import com.stupidbeauty.joyman.data.database.dao.TaskDao;
+import com.stupidbeauty.joyman.data.database.entity.Task;
+
+/**
+ * JoyMan 应用数据库
+ * 
+ * 使用 Room 持久化库管理的 SQLite 数据库
+ * 采用单例模式，确保全局唯一数据库实例
+ * 
+ * 数据库信息：
+ * - 名称：joyman-db
+ * - 版本：1（初始版本）
+ * - 实体类：Task（后续添加 Project、Tag 等）
+ * - DAO 接口：TaskDao（后续添加 ProjectDao 等）
+ * 
+ * 迁移策略：
+ * - 支持增量迁移（addMigrations）
+ * - 破坏性迁移回退（fallbackToDestructiveMigration）
+ * 
+ * @author 太极美术工程狮狮长
+ * @version 1.0.0
+ * @since 2026-03-31
+ */
+@Database(
+    entities = {
+        Task.class
+        // 未来添加：Project.class, Tag.class, Comment.class, etc.
+    },
+    version = 1,
+    exportSchema = true
+)
+public abstract class AppDatabase extends RoomDatabase {
+    
+    /**
+     * 数据库名称
+     */
+    private static final String DATABASE_NAME = "joyman-db";
+    
+    /**
+     * 单例实例
+     */
+    private static volatile AppDatabase INSTANCE;
+    
+    /**
+     * 获取 TaskDao
+     * 
+     * @return Task 数据访问对象
+     */
+    public abstract TaskDao taskDao();
+    
+    /**
+     * 获取数据库实例（单例模式，双重检查锁定）
+     * 
+     * @param context 应用上下文
+     * @return 数据库实例
+     */
+    public static AppDatabase getInstance(Context context) {
+        if (INSTANCE == null) {
+            synchronized (AppDatabase.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = buildDatabase(context.getApplicationContext());
+                }
+            }
+        }
+        return INSTANCE;
+    }
+    
+    /**
+     * 构建数据库实例
+     * 
+     * @param context 应用上下文
+     * @return 数据库实例
+     */
+    @NonNull
+    private static AppDatabase buildDatabase(Context context) {
+        return Room.databaseBuilder(
+                context,
+                AppDatabase.class,
+                DATABASE_NAME
+            )
+            // 添加迁移策略（从版本 1 到版本 2）
+            .addMigrations(MIGRATION_1_2)
+            // 如果没有找到迁移路径，则降级为破坏性迁移（删除所有数据重建）
+            // 生产环境建议移除该行，强制要求提供迁移策略
+            .fallbackToDestructiveMigration()
+            // 允许在主线程查询（仅用于调试，生产环境应使用异步查询）
+            // .allowMainThreadQueries()
+            // 设置数据库回调
+            .addCallback(new Callback() {
+                @Override
+                public void onCreate(@NonNull SupportSQLiteDatabase db) {
+                    super.onCreate(db);
+                    // 数据库首次创建时的初始化逻辑
+                    // 例如：预填充一些默认数据
+                    android.util.Log.d("AppDatabase", "Database created successfully");
+                }
+                
+                @Override
+                public void onOpen(@NonNull SupportSQLiteDatabase db) {
+                    super.onOpen(db);
+                    // 数据库打开时的逻辑
+                    android.util.Log.d("AppDatabase", "Database opened");
+                }
+            })
+            .build();
+    }
+    
+    /**
+     * 数据库迁移策略：版本 1 -> 版本 2
+     * 
+     * 示例：添加 Project 表
+     * （当前为空实现，实际使用时需要填写具体的 SQL 语句）
+     */
+    static final Migration MIGRATION_1_2 = new Migration(1, 2) {
+        @Override
+        public void migrate(@NonNull SupportSQLiteDatabase database) {
+            // 示例：创建新表
+            // database.execSQL("CREATE TABLE IF NOT EXISTS projects (...)");
+            
+            // 示例：添加新字段
+            // database.execSQL("ALTER TABLE tasks ADD COLUMN new_column TEXT DEFAULT ''");
+            
+            // 示例：数据迁移
+            // database.execSQL("UPDATE tasks SET status = 0 WHERE status IS NULL");
+            
+            android.util.Log.d("AppDatabase", "Migrated from version 1 to version 2");
+        }
+    };
+    
+    /**
+     * 关闭数据库
+     * 
+     * 通常在应用退出时调用
+     */
+    public static void closeInstance() {
+        if (INSTANCE != null && INSTANCE.isOpen()) {
+            INSTANCE.close();
+            INSTANCE = null;
+        }
+    }
+}


### PR DESCRIPTION
## 📝 变更说明

本次 PR 添加 JoyMan 项目的 Room 数据库定义 - AppDatabase 类。

### 新增文件
- `app/src/main/java/com/stupidbeauty/joyman/data/database/AppDatabase.java`

### 功能特性
- **Room @Database 注解**: 定义数据库配置和实体类
- **单例模式**: 双重检查锁定，确保全局唯一实例
- **数据库名称**: joyman-db
- **数据库版本**: 1（初始版本）
- **注册实体**: Task（预留 Project、Tag 等扩展）
- **注册 DAO**: taskDao() 方法
- **迁移框架**: 预留 MIGRATION_1_2 示例代码
- **回调支持**: onCreate, onOpen 生命周期回调

### 核心方法

#### 单例访问
- `getInstance(Context)`: 获取数据库实例（线程安全）
- `closeInstance()`: 关闭数据库实例

#### DAO 访问
- `taskDao()`: 获取 TaskDao 接口实例

#### 迁移策略
- `MIGRATION_1_2`: 从版本 1 到版本 2 的迁移框架
  - 支持创建新表
  - 支持添加新字段
  - 支持数据转换
- `fallbackToDestructiveMigration()`: 无迁移时降级为破坏性迁移（开发阶段用）

### 技术细节
- 纯 Java 实现，无 Kotlin 依赖
- 使用 `volatile` 保证多线程可见性
- 使用 `synchronized` 保证线程安全
- 使用应用上下文避免内存泄漏
- 预留日志输出便于调试

### 未来扩展
- 添加 Project 实体时：version = 2，编写实际迁移逻辑
- 添加 Tag、Comment 等实体时：继续递增 version
- 生产环境移除 `fallbackToDestructiveMigration()`

---
**相关 PR**: #11（IdGenerator）、#12（Task 实体）、#13（TaskDao）已合并  
**测试状态**: 待添加单元测试  
**后续计划**: 创建 Project 实体、ProjectDao、Repository 层、UI 层