### PR TITLE
修复：Task 实体添加 project_id 索引声明，解决崩溃

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/data/database/entity/Task.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/data/database/entity/Task.java
@@ -3,6 +3,7 @@ package com.stupidbeauty.joyman.data.database.entity;
 import androidx.room.Entity;
 import androidx.room.PrimaryKey;
 import androidx.room.ColumnInfo;
+import androidx.room.Index;
 import java.util.Date;
 
 /**
@@ -12,10 +13,15 @@ import java.util.Date;
  * 用于存储单个任务的完整信息
  * 
  * @author 太极美术工程狮狮长
- * @version 2.0.0
+ * @version 2.0.1
  * @since 2026-03-31
  */
-@Entity(tableName = "tasks")
+@Entity(
+    tableName = "tasks",
+    indices = {
+        @Index(value = {"project_id"})
+    }
+)
 public class Task {
     
     /**


### PR DESCRIPTION
## 🐛 修复崩溃：Task 实体缺少索引声明

### 问题描述
应用启动时崩溃，错误信息：
```
Migration didn't properly handle: tasks
Expected: indices=[]
Found: indices=[Index{name='index_tasks_project_id', ...}]
```

### 根本原因
- `AppDatabase` 的 MIGRATION_1_2 创建了 `index_tasks_project_id` 索引
- 但 `Task.java` 实体类的 `@Entity` 注解中没有声明这个索引
- Room 验证失败，认为迁移不正确

### 修复方案
在 `Task.java` 的 `@Entity` 注解中添加 `indices` 参数：
```java
@Entity(
    tableName = "tasks",
    indices = {
        @Index(value = {"project_id"})
    }
)
public class Task {
    // ...
}
```

### 影响范围
- ✅ 仅修改实体类注解
- ✅ 不改变数据库结构
- ✅ 不改变迁移逻辑
- ✅ 仅修复 Room 验证问题

---
**相关 Issue**: N/A  
**测试状态**: 待 CI 验证 + 真机测试