### PR TITLE
修复：TaskDetailActivity 正确显示当前所属项目

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/TaskDetailActivity.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/TaskDetailActivity.java
@@ -1,3 +1,251 @@
+package com.stupidbeauty.joyman;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.view.MenuItem;
+import android.widget.ArrayAdapter;
+import android.widget.Spinner;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.ViewModelProvider;
+
+import com.stupidbeauty.joyman.data.database.entity.Project;
+import com.stupidbeauty.joyman.data.database.entity.Task;
+import com.stupidbeauty.joyman.viewmodel.ProjectViewModel;
+import com.stupidbeauty.joyman.viewmodel.TaskViewModel;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * 任务详情界面
+ * 
+ * @author 太极美术工程狮狮长
+ * @version 1.0.2
+ * @since 2026-04-01
+ */
+public class TaskDetailActivity extends AppCompatActivity {
+    
+    public static final String EXTRA_TASK_ID = "task_id";
+    private static final String TAG = "TaskDetailActivity";
+    
+    private long taskId;
+    private Task task;
+    private TaskViewModel taskViewModel;
+    private ProjectViewModel projectViewModel;
+    
+    private TextView textTitle;
+    private TextView textDescription;
+    private TextView textStatus;
+    private TextView textPriority;
+    private TextView textProject;
+    private TextView textCreatedAt;
+    private Spinner spinnerProject;
+    
+    private List<Project> projectList;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Log.d(TAG, "=================================================================");
+        Log.d(TAG, "onCreate: START - Activity created");
+        Log.d(TAG, "onCreate: Task ID from intent: " + getIntent().getLongExtra(EXTRA_TASK_ID, 0));
+        Log.d(TAG, "onCreate: Activity hash code: " + this.hashCode());
+        
+        setContentView(R.layout.activity_task_detail);
+        
+        setSupportActionBar(findViewById(R.id.toolbar));
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setTitle("任务详情");
+        }
+        
+        taskId = getIntent().getLongExtra(EXTRA_TASK_ID, 0);
+        if (taskId == 0) {
+            Log.e(TAG, "onCreate: Invalid task ID!");
+            Toast.makeText(this, "无效的任务 ID", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
+        
+        Log.d(TAG, "onCreate: Getting ViewModels");
+        taskViewModel = new ViewModelProvider(this).get(TaskViewModel.class);
+        projectViewModel = new ViewModelProvider(this).get(ProjectViewModel.class);
+        Log.d(TAG, "onCreate: TaskViewModel hash code: " + taskViewModel.hashCode());
+        Log.d(TAG, "onCreate: ProjectViewModel hash code: " + projectViewModel.hashCode());
+        
+        initViews();
+        loadTask();
+        loadProjects();
+        
+        Log.d(TAG, "onCreate: END");
+        Log.d(TAG, "=================================================================");
+    }
+    
+    private void initViews() {
+        Log.d(TAG, "initViews: Initializing views");
+        textTitle = findViewById(R.id.text_detail_title);
+        textDescription = findViewById(R.id.text_detail_description);
+        textStatus = findViewById(R.id.text_detail_status);
+        textPriority = findViewById(R.id.text_detail_priority);
+        textProject = findViewById(R.id.text_detail_project);
+        textCreatedAt = findViewById(R.id.text_detail_created_at);
+        spinnerProject = findViewById(R.id.spinner_detail_project);
+        
+        findViewById(R.id.btn_toggle_status).setOnClickListener(v -> toggleStatus());
+        findViewById(R.id.btn_move_project).setOnClickListener(v -> showMoveProjectDialog());
+        findViewById(R.id.btn_delete).setOnClickListener(v -> showDeleteConfirm());
+        Log.d(TAG, "initViews: Views initialized and listeners set");
+    }
+    
+    private void loadTask() {
+        Log.d(TAG, "loadTask: Loading task ID: " + taskId);
+        taskViewModel.getTaskById(taskId).observe(this, task -> {
+            Log.d(TAG, "loadTask: Observer triggered, task is null: " + (task == null));
+            if (task == null) {
+                Log.e(TAG, "loadTask: Task not found!");
+                Toast.makeText(this, "任务不存在", Toast.LENGTH_SHORT).show();
+                finish();
+                return;
+            }
+            
+            this.task = task;
+            Log.d(TAG, "loadTask: Task loaded - ID: " + task.getId() + ", title: " + task.getTitle() + ", projectId: " + task.getProjectId());
+            updateUI();
+        });
+    }
+    
+    private void loadProjects() {
+        Log.d(TAG, "loadProjects: START - Loading projects for spinner");
+        Log.d(TAG, "loadProjects: Activity is destroyed: " + isDestroyed());
+        Log.d(TAG, "loadProjects: Activity is finishing: " + isFinishing());
+        
+        projectViewModel.getAllProjects().observe(this, projects -> {
+            Log.d(TAG, "loadProjects: Observer triggered, projects is null: " + (projects == null));
+            Log.d(TAG, "loadProjects: Activity is destroyed: " + isDestroyed());
+            
+            if (isDestroyed()) {
+                Log.w(TAG, "loadProjects: Activity already destroyed, skipping update");
+                return;
+            }
+            
+            projectList = new ArrayList<>();
+            List<String> projectNames = new ArrayList<>();
+            
+            // 添加"无项目"选项
+            projectList.add(null);
+            projectNames.add("无项目");
+            Log.d(TAG, "loadProjects: Added 'no project' option");
+            
+            // 添加所有项目
+            if (projects != null) {
+                for (Project project : projects) {
+                    projectList.add(project);
+                    projectNames.add(project.getIconDisplay() + " " + project.getName());
+                }
+                Log.d(TAG, "loadProjects: Added " + projects.size() + " projects");
+            } else {
+                Log.w(TAG, "loadProjects: Projects list is null");
+            }
+            
+            ArrayAdapter<String> adapter = new ArrayAdapter<>(
+                this,
+                android.R.layout.simple_spinner_item,
+                projectNames
+            );
+            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+            spinnerProject.setAdapter(adapter);
+            Log.d(TAG, "loadProjects: Adapter created and set");
+            
+            // 设置当前选中的项目
+            if (task != null && task.getProjectId() != null) {
+                Log.d(TAG, "loadProjects: Setting selection for task with projectId: " + task.getProjectId());
+                for (int i = 0; i < projectList.size(); i++) {
+                    Project p = projectList.get(i);
+                    if (p != null && p.getId() == task.getProjectId()) {
+                        spinnerProject.setSelection(i);
+                        Log.d(TAG, "loadProjects: Selected index: " + i);
+                        break;
+                    }
+                }
+            } else {
+                Log.d(TAG, "loadProjects: Task has no project, selecting 'no project'");
+                spinnerProject.setSelection(0);
+            }
+            
+            // 监听项目选择变化
+            spinnerProject.setOnItemSelectedListener(new android.widget.AdapterView.OnItemSelectedListener() {
+                @Override
+                public void onItemSelected(android.widget.AdapterView<?> parent, android.view.View view, int position, long id) {
+                    Log.d(TAG, "=================================================================");
+                    Log.d(TAG, "onItemSelected: START - Position: " + position);
+                    Log.d(TAG, "onItemSelected: Activity is destroyed: " + isDestroyed());
+                    Log.d(TAG, "onItemSelected: Activity is finishing: " + isFinishing());
+                    
+                    if (isDestroyed()) {
+                        Log.w(TAG, "onItemSelected: Activity already destroyed, ignoring selection");
+                        return;
+                    }
+                    
+                    if (position >= projectList.size()) {
+                        Log.e(TAG, "onItemSelected: Invalid position: " + position + ", projectList size: " + projectList.size());
+                        return;
+                    }
+                    
+                    Project selectedProject = projectList.get(position);
+                    Log.d(TAG, "onItemSelected: Selected project: " + (selectedProject == null ? "null" : selectedProject.getName()));
+                    Log.d(TAG, "onItemSelected: Current task projectId: " + (task == null ? "null" : task.getProjectId()));
+                    
+                    if (selectedProject == null) {
+                        // 选择了"无项目"
+                        if (task != null && task.getProjectId() != null) {
+                            Log.i(TAG, "onItemSelected: Removing project association");
+                            task.setProjectId(null);
+                            taskViewModel.update(task);
+                            Toast.makeText(TaskDetailActivity.this, "已移除项目关联", Toast.LENGTH_SHORT).show();
+                        } else {
+                            Log.d(TAG, "onItemSelected: No change needed (already no project)");
+                        }
+                    } else {
+                        // 选择了具体项目
+                        if (task == null) {
+                            Log.e(TAG, "onItemSelected: Task is null!");
+                            return;
+                        }
+                        
+                        if (task.getProjectId() == null || task.getProjectId() != selectedProject.getId()) {
+                            Log.i(TAG, "onItemSelected: Moving task to project: " + selectedProject.getName() + " (ID: " + selectedProject.getId() + ")");
+                            task.setProjectId(selectedProject.getId());
+                            Log.d(TAG, "onItemSelected: Calling taskViewModel.update()");
+                            taskViewModel.update(task);
+                            Toast.makeText(TaskDetailActivity.this, "已移动到项目：" + selectedProject.getName(), Toast.LENGTH_SHORT).show();
+                        } else {
+                            Log.d(TAG, "onItemSelected: No change needed (same project)");
+                        }
+                    }
+                    
+                    updateUI();
+                    Log.d(TAG, "onItemSelected: END");
+                    Log.d(TAG, "=================================================================");
+                }
+                
+                @Override
+                public void onNothingSelected(android.widget.AdapterView<?> parent) {
+                    Log.d(TAG, "onNothingSelected: Called");
+                }
+            });
+            
+            Log.d(TAG, "loadProjects: Listener set up");
+            Log.d(TAG, "loadProjects: END");
+        });
+    }
+    
     private void updateUI() {
         Log.d(TAG, "updateUI: START - Updating UI");
         if (task == null) {
@@ -55,3 +303,108 @@
         
         Log.d(TAG, "updateUI: END - UI updated");
     }
+    
+    private void toggleStatus() {
+        Log.d(TAG, "toggleStatus: Toggling status for task ID: " + taskId);
+        if (task == null) {
+            Log.w(TAG, "toggleStatus: Task is null");
+            return;
+        }
+        
+        if (task.isDone()) {
+            taskViewModel.markAsTodo(taskId);
+            Toast.makeText(this, "已标记为待办", Toast.LENGTH_SHORT).show();
+        } else {
+            taskViewModel.markAsDone(taskId);
+            Toast.makeText(this, "已标记为完成", Toast.LENGTH_SHORT).show();
+        }
+    }
+    
+    private void showMoveProjectDialog() {
+        Log.d(TAG, "showMoveProjectDialog: Showing dialog");
+        if (projectList == null) {
+            Log.w(TAG, "showMoveProjectDialog: Project list not loaded yet");
+            Toast.makeText(this, "项目列表加载中...", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        
+        String[] projectNames = new String[projectList.size()];
+        for (int i = 0; i < projectList.size(); i++) {
+            Project p = projectList.get(i);
+            projectNames[i] = (p == null) ? "无项目" : (p.getIconDisplay() + " " + p.getName());
+        }
+        
+        int currentIndex = 0;
+        if (task != null && task.getProjectId() != null) {
+            for (int i = 0; i < projectList.size(); i++) {
+                Project p = projectList.get(i);
+                if (p != null && p.getId() == task.getProjectId()) {
+                    currentIndex = i;
+                    break;
+                }
+            }
+        }
+        
+        new AlertDialog.Builder(this)
+            .setTitle("移动到项目")
+            .setSingleChoiceItems(projectNames, currentIndex, (dialog, which) -> {
+                Log.d(TAG, "showMoveProjectDialog: Dialog item clicked, position: " + which);
+                Project selectedProject = projectList.get(which);
+                if (selectedProject == null) {
+                    task.setProjectId(null);
+                } else {
+                    task.setProjectId(selectedProject.getId());
+                }
+                taskViewModel.update(task);
+                
+                String projectName = (selectedProject == null) ? "无项目" : selectedProject.getName();
+                Toast.makeText(this, "已移动到：" + projectName, Toast.LENGTH_SHORT).show();
+                
+                dialog.dismiss();
+                updateUI();
+            })
+            .setNegativeButton("取消", null)
+            .show();
+    }
+    
+    private void showDeleteConfirm() {
+        Log.d(TAG, "showDeleteConfirm: Showing delete confirmation");
+        if (task == null) {
+            Log.w(TAG, "showDeleteConfirm: Task is null");
+            return;
+        }
+        
+        new AlertDialog.Builder(this)
+            .setTitle("删除任务")
+            .setMessage("确定要删除任务 \"" + task.getTitle() + "\" 吗？")
+            .setPositiveButton("删除", (dialog, which) -> {
+                Log.i(TAG, "showDeleteConfirm: User confirmed deletion");
+                taskViewModel.deleteById(taskId);
+                Toast.makeText(this, "任务已删除", Toast.LENGTH_SHORT).show();
+                finish();
+            })
+            .setNegativeButton("取消", null)
+            .show();
+    }
+    
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            Log.d(TAG, "onOptionsItemSelected: Home button clicked, finishing activity");
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+    
+    @Override
+    protected void onDestroy() {
+        Log.d(TAG, "=================================================================");
+        Log.d(TAG, "onDestroy: START - Activity being destroyed");
+        Log.d(TAG, "onDestroy: Activity hash code: " + this.hashCode());
+        Log.d(TAG, "onDestroy: Task ID: " + taskId);
+        super.onDestroy();
+        Log.d(TAG, "onDestroy: END");
+        Log.d(TAG, "=================================================================");
+    }
+}


### PR DESCRIPTION
## 🐛 修复：TaskDetailActivity 正确显示当前所属项目

### 问题描述
进入任务详情页后，"所属项目"字段显示为空白，没有正确显示任务当前所在的项目。

### 根本原因
在 `updateUI()` 方法中：
1. 使用 `observe()` 异步加载项目列表
2. 如果项目列表加载延迟，UI 可能先显示空白
3. 找到项目后没有日志确认，难以排查问题

### 修复方案
1. **添加详细日志**：追踪项目查找的完整流程
   - 记录任务的 project ID
   - 记录加载到的项目数量
   - 记录每个项目的比对过程
   - 记录是否找到匹配的项目

2. **兜底显示**：如果找不到对应的项目
   - 显示"未知项目 (ID: xxx)"而不是空白
   - 便于发现数据不一致问题

3. **使用 Log.i 级别**：确保关键信息在默认日志级别可见

### 日志输出示例
**成功找到项目：**
```
TaskDetailActivity: updateUI: Task project ID: 1234567890
TaskDetailActivity: updateUI: Observing projects to find project ID: 1234567890
TaskDetailActivity: updateUI: Projects observer triggered, projects count: 2
TaskDetailActivity: updateUI: Checking project: 1234567890 - 基础设施
TaskDetailActivity: updateUI: Project found! Display: 所属项目：📁 基础设施
```

**未找到项目：**
```
TaskDetailActivity: updateUI: Task project ID: 9999999999
TaskDetailActivity: updateUI: Projects observer triggered, projects count: 2
TaskDetailActivity: updateUI: Checking project: 1234567890 - 基础设施
TaskDetailActivity: updateUI: Checking project: 2345678901 - 家庭事务
TaskDetailActivity: updateUI: Project not found! ID: 9999999999
```
显示：`所属项目：未知项目 (ID: 9999999999)`

---
**相关 PR**: #30 (包含崩溃修复和日志)  
**测试状态**: 待审核合并后测试