### PR TITLE
修复：Spinner 手动保存 + 日志文件输出 + Spinner 显示修正

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/TaskDetailActivity.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/TaskDetailActivity.java
@@ -28,7 +28,7 @@ import java.util.Locale;
  * 任务详情界面
  * 
  * @author 太极美术工程狮狮长
- * @version 1.0.5
+ * @version 1.0.6
  * @since 2026-04-01
  */
 public class TaskDetailActivity extends AppCompatActivity {
@@ -164,61 +164,7 @@ public class TaskDetailActivity extends AppCompatActivity {
             spinnerProject.setAdapter(adapter);
             LogUtils.getInstance().d(TAG, "loadProjects: Adapter created and set");
             
-            if (task != null && task.getProjectId() != null) {
-                LogUtils.getInstance().d(TAG, "loadProjects: Setting selection for task with projectId: " + task.getProjectId());
-                for (int i = 0; i < projectList.size(); i++) {
-                    Project p = projectList.get(i);
-                    if (p != null && p.getId() == task.getProjectId()) {
-                        spinnerProject.setSelection(i);
-                        LogUtils.getInstance().d(TAG, "loadProjects: Selected index: " + i);
-                        break;
-                    }
-                }
-            } else {
-                LogUtils.getInstance().d(TAG, "loadProjects: Task has no project, selecting 'no project'");
-                spinnerProject.setSelection(0);
-            }
-            
-            spinnerProject.setOnItemSelectedListener(new android.widget.AdapterView.OnItemSelectedListener() {
-                @Override
-                public void onItemSelected(android.widget.AdapterView<?> parent, android.view.View view, int position, long id) {
-                    LogUtils.getInstance().d(TAG, "=================================================================");
-                    LogUtils.getInstance().d(TAG, "onItemSelected: START - Position: " + position);
-                    LogUtils.getInstance().d(TAG, "onItemSelected: Activity is destroyed: " + isDestroyed());
-                    LogUtils.getInstance().d(TAG, "onItemSelected: Activity is finishing: " + isFinishing());
-                    
-                    if (isDestroyed()) {
-                        LogUtils.getInstance().w(TAG, "onItemSelected: Activity already destroyed, ignoring selection");
-                        return;
-                    }
-                    
-                    if (position >= projectList.size()) {
-                        LogUtils.getInstance().e(TAG, "onItemSelected: Invalid position: " + position + ", projectList size: " + projectList.size());
-                        return;
-                    }
-                    
-                    Project selectedProject = projectList.get(position);
-                    LogUtils.getInstance().d(TAG, "onItemSelected: Selected project: " + (selectedProject == null ? "null" : selectedProject.getName()));
-                    LogUtils.getInstance().d(TAG, "onItemSelected: Current task projectId: " + (task == null ? "null" : task.getProjectId()));
-                    
-                    if (selectedProject == null) {
-                        pendingProjectId = null;
-                        LogUtils.getInstance().d(TAG, "onItemSelected: Pending project set to null");
-                    } else {
-                        pendingProjectId = selectedProject.getId();
-                        LogUtils.getInstance().d(TAG, "onItemSelected: Pending project set to: " + selectedProject.getId());
-                    }
-                    
-                    LogUtils.getInstance().d(TAG, "onItemSelected: END (waiting for manual save)");
-                    LogUtils.getInstance().d(TAG, "=================================================================");
-                }
-                
-                @Override
-                public void onNothingSelected(android.widget.AdapterView<?> parent) {
-                    LogUtils.getInstance().d(TAG, "onNothingSelected: Called");
-                }
-            });
-            
+            // 注意：不在这里设置选择位置，等 updateUI() 中统一设置
             LogUtils.getInstance().d(TAG, "loadProjects: Listener set up");
             LogUtils.getInstance().d(TAG, "loadProjects: END");
         });
@@ -314,6 +260,18 @@ public class TaskDetailActivity extends AppCompatActivity {
                             textProject.setText(projectDisplay);
                             LogUtils.getInstance().i(TAG, "updateUI: Project found! Display: " + projectDisplay);
                             found = true;
+                            
+                            // 同时更新 Spinner 的选择位置
+                            if (projectList != null) {
+                                for (int i = 0; i < projectList.size(); i++) {
+                                    Project sp = projectList.get(i);
+                                    if (sp != null && sp.getId() == projectId) {
+                                        LogUtils.getInstance().d(TAG, "updateUI: Setting spinner selection to index: " + i);
+                                        spinnerProject.setSelection(i);
+                                        break;
+                                    }
+                                }
+                            }
                             break;
                         }
                     }
@@ -327,6 +285,10 @@ public class TaskDetailActivity extends AppCompatActivity {
         } else {
             LogUtils.getInstance().i(TAG, "updateUI: Task has no project");
             textProject.setText("所属项目：无");
+            if (projectList != null) {
+                LogUtils.getInstance().d(TAG, "updateUI: Setting spinner selection to index: 0 (no project)");
+                spinnerProject.setSelection(0);
+            }
         }
         
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault());


### PR DESCRIPTION
## 修复内容

### 1. Spinner 项目选择修复
- ✅ 移除 `onItemSelected()` 中的自动保存逻辑，避免初始化时误触发
- ✅ Spinner 仅用于显示当前项目，选择后不立即保存
- ✅ 添加 `saveProjectSelection()` 方法，点击"保存项目更改"按钮时才执行数据库更新
- ✅ 添加 `pendingProjectId` 变量暂存用户选择
- ✅ **修复 Spinner 初始选择位置不正确的问题**（在 updateUI 中同步设置）

### 2. 日志文件输出功能
- ✅ 创建 `LogUtils` 单例工具类
- ✅ 支持同时输出到 Logcat 和文件
- ✅ 日志文件保存在 `/sdcard/Download/joyman_logs/joyman_YYYY-MM-DD.log`
- ✅ 按日期自动分割日志文件
- ✅ 线程安全的异步写入操作
- ✅ `TaskDetailActivity` 所有日志改用 `LogUtils`

### 3. 布局文件更新
- ✅ 在 Spinner 下方添加绿色"保存项目更改"按钮
- ✅ 调整布局顺序和间距

## 测试步骤

1. 安装新版本 APK
2. 打开任务详情页
3. **验证 Spinner 正确显示当前所属项目**（修复前会显示"无项目"）
4. 从 Spinner 选择一个**不同**的项目
5. 点击绿色的"保存项目更改"按钮
6. 查看 Toast 提示（应显示"已保存到：📁 xxx"）
7. 用文件管理器查看 `/sdcard/Download/joyman_logs/` 目录下的日志文件

## 相关文件

- `app/src/main/java/com/stupidbeauty/joyman/util/LogUtils.java` (新增)
- `app/src/main/java/com/stupidbeauty/joyman/TaskDetailActivity.java` (修改)
- `app/src/main/res/layout/activity_task_detail.xml` (修改)

## 版本历史

- v1.0.5: 修复编译错误（long 不能调用 getClass()）
- v1.0.6: 修复 Spinner 初始选择位置不正确的问题

## 关联 Issue

- 修复 Spinner 初始化时误触发保存的问题
- 修复 Spinner 显示与任务实际所属项目不一致的问题
- 支持日志文件输出，方便手机端调试