### PR TITLE
feat: 日志文件按小时分割，避免单日文件过大

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/util/LogUtils.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/util/LogUtils.java
@@ -14,12 +14,13 @@ import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+
 /**
  * 日志工具类
  * 支持同时输出到 Logcat 和文件
  * 
  * @author 太极美术工程狮狮长
- * @version 1.0.0
+ * @version 1.1.0
  * @since 2026-04-01
  */
 public class LogUtils {
@@ -33,7 +34,9 @@ public class LogUtils {
     private ExecutorService executorService;
     private String currentLogFile;
     private SimpleDateFormat dateFormat;
+    private SimpleDateFormat hourFormat;
     private SimpleDateFormat timeFormat;
+    private String lastHourKey;
     
     /**
      * 获取单例实例
@@ -48,17 +51,26 @@ public class LogUtils {
     private LogUtils() {
         executorService = Executors.newSingleThreadExecutor();
         dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
+        hourFormat = new SimpleDateFormat("HH", Locale.getDefault());
         timeFormat = new SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault());
+        lastHourKey = null;
         updateCurrentLogFile();
     }
     
     /**
-     * 更新当前日志文件路径（按日期分割）
+     * 更新当前日志文件路径（按小时分割）
      */
     private void updateCurrentLogFile() {
         String dateStr = dateFormat.format(new Date());
-        File logDir = getLogDirectory();
-        currentLogFile = new File(logDir, LOG_FILE_PREFIX + dateStr + LOG_FILE_SUFFIX).getAbsolutePath();
+        String hourStr = hourFormat.format(new Date());
+        String currentHourKey = dateStr + "_" + hourStr;
+        
+        // 只有当小时变化时才更新文件路径
+        if (!currentHourKey.equals(lastHourKey)) {
+            lastHourKey = currentHourKey;
+            File logDir = getLogDirectory();
+            currentLogFile = new File(logDir, LOG_FILE_PREFIX + dateStr + "_" + hourStr + LOG_FILE_SUFFIX).getAbsolutePath();
+        }
     }
     
     /**
@@ -78,7 +90,7 @@ public class LogUtils {
      */
     private void writeToFile(final String level, final String tag, final String message, final Throwable throwable) {
         executorService.execute(() -> {
-            // 检查是否需要切换日志文件（跨天情况）
+            // 检查是否需要切换日志文件（跨小时情况）
             updateCurrentLogFile();
             
             String timestamp = timeFormat.format(new Date());


### PR DESCRIPTION
## 变更说明

### 问题背景
当前日志文件按天命名（`joyman_YYYY-MM-DD.log`），导致单日单个日志文件过大，不便查看和管理。

### 解决方案
将日志文件命名策略改为**按小时分割**：
- 新格式：`joyman_YYYY-MM-DD_HH.log`
- 示例：`joyman_2026-04-03_19.log`

### 主要改动
1. **新增字段**：
   - `hourFormat`: 用于格式化小时部分
   - `lastHourKey`: 记录上一次的小时密钥，用于检测小时变化

2. **修改逻辑**：
   - `updateCurrentLogFile()`: 改为按小时检查并更新日志文件路径
   - 只有当小时变化时才创建新文件，避免不必要的文件操作

3. **版本升级**：
   - 从 1.0.0 升级至 1.1.0

### 测试建议
- 验证日志文件是否每小时自动切换
- 确认跨天时日志文件正常创建（如 `joyman_2026-04-03_23.log` → `joyman_2026-04-04_00.log`）
- 检查 Logcat 输出和异常堆栈功能是否正常

### 相关文件
- `app/src/main/java/com/stupidbeauty/joyman/util/LogUtils.java`

---
📝 此 PR 解决任务：**日志文件名要带更多信息，避免单日单个日志文件太大**