### PR TITLE
feat: 任务详情界面状态管理 + 数据库版本修复

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/data/database/AppDatabase.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/data/database/AppDatabase.java
@@ -14,16 +14,17 @@ import com.stupidbeauty.joyman.data.database.dao.TaskDao;
 import com.stupidbeauty.joyman.data.database.entity.Project;
 import com.stupidbeauty.joyman.data.database.entity.Task;
 
+
 /**
  * JoyMan 应用数据库
  * 
  * 数据库信息：
  * - 名称：joyman-db
- * - 版本：2（支持任务关联项目）
+ * - 版本：3（任务状态常量扩展）
  * - 实体类：Task, Project
  * 
  * @author 太极美术工程狮狮长
- * @version 2.0.0
+ * @version 3.0.0
  * @since 2026-03-31
  */
 @Database(
@@ -31,7 +32,7 @@ import com.stupidbeauty.joyman.data.database.entity.Task;
         Task.class,
         Project.class
     },
-    version = 2,
+    version = 3,
     exportSchema = false
 )
 public abstract class AppDatabase extends RoomDatabase {
@@ -60,7 +61,7 @@ public abstract class AppDatabase extends RoomDatabase {
                 AppDatabase.class,
                 DATABASE_NAME
             )
-            .addMigrations(MIGRATION_1_2)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
             .fallbackToDestructiveMigration()
             .addCallback(new Callback() {
                 @Override
@@ -95,6 +96,21 @@ public abstract class AppDatabase extends RoomDatabase {
             database.execSQL("CREATE INDEX IF NOT EXISTS index_tasks_project_id ON tasks(project_id)");
             
             android.util.Log.d("AppDatabase", "Migrated from version 1 to version 2: Added project_id column");
+        }
+    };
+    
+    /**
+     * 数据库迁移：版本 2 → 版本 3
+     * 
+     * 变更内容：
+     * - Task 实体类状态常量扩展（STATUS_NEW, STATUS_IN_PROGRESS, STATUS_RESOLVED, STATUS_FEEDBACK, STATUS_CLOSED）
+     * - 无实际数据库 schema 变更，仅更新版本号以匹配新的 identity hash
+     */
+    static final Migration MIGRATION_2_3 = new Migration(2, 3) {
+        @Override
+        public void migrate(@NonNull SupportSQLiteDatabase database) {
+            // 无需实际迁移操作，Task 实体类的 Java 常量变更不影响数据库 schema
+            android.util.Log.d("AppDatabase", "Migrated from version 2 to version 3: Updated status constants");
         }
     };
     


### PR DESCRIPTION
## 变更内容

完善任务详情界面的状态管理功能，并修复数据库版本不匹配导致的崩溃问题。

### 核心功能

#### 1. 任务状态扩展 (Task.java)
- 新增 5 个与 Redmine 兼容的状态常量：
  - `STATUS_NEW = 1` (新建)
  - `STATUS_IN_PROGRESS = 2` (进行中)
  - `STATUS_RESOLVED = 3` (已解决)
  - `STATUS_FEEDBACK = 4` (反馈中)
  - `STATUS_CLOSED = 5` (已关闭)
- 添加 `getStatusNameById()` 静态方法
- 添加 `getDefaultStatusIds()` 和 `getDefaultStatusNames()` 辅助方法

#### 2. 状态颜色定义 (colors.xml)
```xml
<color name="status_new">#2196F3</color>          <!-- 蓝色 -->
<color name="status_in_progress">#FF9800</color>  <!-- 橙色 -->
<color name="status_resolved">#4CAF50</color>    <!-- 绿色 -->
<color name="status_feedback">#9C27B0</color>    <!-- 紫色 -->
<color name="status_closed">#9E9E9E</color>      <!-- 灰色 -->
```

#### 3. 任务详情界面 UI (activity_task_detail.xml)
- 状态下拉选择器 (`spinner_status`)
- 统一的"保存更改"按钮 (`btn_save_changes`)
- 状态文本带颜色显示

#### 4. 任务详情逻辑 (TaskDetailActivity.java)
- `pendingStatusId` 和 `pendingProjectId` 暂存变更
- `updateSaveButtonState()` 动态更新按钮状态和文本
- `saveAllChanges()` 一次性保存所有待处理变更
- 状态变更即时反馈（Toast 提示）

#### 5. 数据库版本修复 (AppDatabase.java) ⚠️ **关键修复**
- 数据库版本：2 → 3
- 新增 `MIGRATION_2_3` 迁移
- 修复 Room identity hash 不匹配导致的崩溃

### 用户体验改进

- ✅ 支持下拉选择任意状态（5 选 1）
- ✅ 状态文本颜色与状态含义匹配
- ✅ 统一保存按钮，避免误操作
- ✅ 按钮动态显示待保存的变更类型
- ✅ 无变更时按钮禁用并半透明显示
- ✅ **修复启动崩溃问题**

### 技术细节

- 使用 `ContextCompat.getColor()` 获取颜色资源
- 状态 ID 到颜色索引的映射：`colorIndex = statusId - STATUS_NEW`
- 暂存机制：变更先暂存，点击保存按钮后才写入数据库
- 数据库迁移策略：空迁移 + `fallbackToDestructiveMigration()` 后备

### 测试建议

- [ ] **全新安装**：验证应用正常启动，无崩溃
- [ ] **升级安装**：从旧版本升级，验证数据不丢失
- [ ] 打开任务详情，验证默认状态显示正确
- [ ] 切换不同状态，验证 UI 颜色和文本更新
- [ ] 同时修改状态和项目，验证统一保存按钮工作正常
- [ ] 验证所有 5 种状态的颜色区分明显

---
**关联 Issue**: 任务详情界面状态显示功能
**依赖**: Task.java v2.0.3, colors.xml 扩展
**注意**: 此 PR 包含关键的数据库版本修复，必须测试升级场景