### PR TITLE
chore: 升级 android-crash-detector 到 2026.4.8（自动崩溃报告界面）

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,8 +59,8 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
     
     // 🆕 Android Crash Detector - 崩溃报告界面（库自动注册 Activity）
-    // 版本：2026.4.6 → 2026.4.7
-    implementation 'com.github.hxcan:android-crash-detector:2026.4.7'
+    // 版本：2026.4.8 (基于 PR #9 合并后的正式版本)
+    implementation 'com.github.hxcan:android-crash-detector:2026.4.8'
     
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'


### PR DESCRIPTION
## 变更内容

升级 android-crash-detector 库到最新版本，启用自动崩溃报告界面功能。

### 依赖升级

**android-crash-detector**: `2026.4.6` → `2026.4.8`

### 新版本特性 (2026.4.8)

#### 🎯 自动注册 CrashReportActivity
- 库的 AndroidManifest.xml 中已注册 CrashReportActivity
- **joyman 无需手动配置**
- 崩溃时自动弹出报告界面
- PR #9 已合并到上游仓库

#### 📋 崩溃报告界面功能
- 展示崩溃详情（堆栈跟踪、设备信息、应用版本）
- 支持复制到剪贴板
- 支持分享崩溃报告
- 运行在独立进程 `:crash`，即使主应用崩溃也能显示

### 版本历史

| 版本 | 变更 |
|------|------|
| 2026.4.8 | ✅ 基于 PR #9 合并后的正式版本 |
| 2026.4.7 | ❌ 未合并 PR 即发布（已废弃） |
| 2026.4.6 | 旧版本，需手动配置 Activity |

### 测试建议

- [ ] 编译安装新版本
- [ ] 触发一次崩溃（如故意访问空对象）
- [ ] 验证崩溃报告界面自动弹出
- [ ] 测试"复制到剪贴板"功能
- [ ] 测试"分享"功能
- [ ] 检查崩溃日志文件生成

---
**上游 PR**: hxcan/android-crash-detector#9 (已合并)
**上游 Release**: https://github.com/hxcan/android-crash-detector/releases/tag/2026.4.8
**合并 commit**: 2967bb6c9fd827d55d6718d774d2a5d8da23b87