### PR TITLE
feat: 任务详情界面状态管理 + 数据库迁移修复（无损升级）

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/data/database/AppDatabase.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/data/database/AppDatabase.java
@@ -24,7 +24,7 @@ import com.stupidbeauty.joyman.data.database.entity.Task;
  * - 实体类：Task, Project
  * 
  * @author 太极美术工程狮狮长
- * @version 3.0.0
+ * @version 3.0.1
  * @since 2026-03-31
  */
 @Database(
@@ -103,14 +103,18 @@ public abstract class AppDatabase extends RoomDatabase {
      * 数据库迁移：版本 2 → 版本 3
      * 
      * 变更内容：
-     * - Task 实体类状态常量扩展（STATUS_NEW, STATUS_IN_PROGRESS, STATUS_RESOLVED, STATUS_FEEDBACK, STATUS_CLOSED）
-     * - 无实际数据库 schema 变更，仅更新版本号以匹配新的 identity hash
+     * - Task 实体类状态常量扩展（STATUS_NEW=1, STATUS_IN_PROGRESS=2, STATUS_RESOLVED=3, STATUS_FEEDBACK=4, STATUS_CLOSED=5）
+     * - 更新现有任务的状态值：0 (STATUS_TODO) → 1 (STATUS_NEW)
+     * - 修复 Room schema 验证失败问题
      */
     static final Migration MIGRATION_2_3 = new Migration(2, 3) {
         @Override
         public void migrate(@NonNull SupportSQLiteDatabase database) {
-            // 无需实际迁移操作，Task 实体类的 Java 常量变更不影响数据库 schema
-            android.util.Log.d("AppDatabase", "Migrated from version 2 to version 3: Updated status constants");
+            // 将旧版本 status=0 (STATUS_TODO) 更新为 status=1 (STATUS_NEW)
+            // 确保现有任务数据在升级后保持正确的状态映射
+            database.execSQL("UPDATE tasks SET status = 1 WHERE status = 0");
+            
+            android.util.Log.d("AppDatabase", "Migrated from version 2 to version 3: Updated status constants and migrated existing tasks");
         }
     };
     


### PR DESCRIPTION
## 变更内容

完善任务详情界面的状态管理功能，并修复数据库版本不匹配导致的崩溃问题。

### 核心功能

#### 1. 任务状态扩展 (Task.java)
- 新增 5 个与 Redmine 兼容的状态常量
- `STATUS_NEW = 1`, `STATUS_IN_PROGRESS = 2`, `STATUS_RESOLVED = 3`, `STATUS_FEEDBACK = 4`, `STATUS_CLOSED = 5`

#### 2. 状态颜色定义 (colors.xml)
- 5 种状态对应颜色：蓝/橙/绿/紫/灰

#### 3. 任务详情界面 UI
- 状态下拉选择器
- 统一保存按钮（状态 + 项目）
- 状态文本带颜色显示

#### 4. 数据库版本修复 (AppDatabase.java) ⚠️ **关键修复**
- 数据库版本：2 → 3
- **MIGRATION_2_3**: `UPDATE tasks SET status = 1 WHERE status = 0`
- 无损升级，保留所有用户数据

### 测试建议
- [ ] 升级安装验证数据库迁移
- [ ] 现有任务状态正确映射（待办→新建）
- [ ] 状态下拉选择器工作正常
- [ ] 颜色显示正确

---
**注意**: 此 PR 包含关键的数据库迁移修复