### PR TITLE
chore: 升级版本码到 3（包含数据库迁移修复）

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.stupidbeauty.joyman"
         minSdk 24
         targetSdk 34
-        versionCode 2
-        versionName "2026.3.31"
+        versionCode 3
+        versionName "2026.4.4"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## 变更内容

升级应用版本号，匹配数据库版本。

### 版本更新
- **versionCode**: 2 → 3
- **versionName**: 2026.3.31 → 2026.4.4

### 包含功能
- ✅ PR #50: 任务详情界面状态管理 + 数据库迁移修复
- ✅ PR #49: android-crash-detector 2026.4.8（崩溃报告界面）
- ✅ 数据库版本：3（包含 MIGRATION_2_3 无损迁移）

### 为什么需要升级
PR #50 合并了数据库迁移修复，但忘记更新 versionCode，导致：
- CI 编译的 APK 版本码是 2
- 但 AppDatabase.java 的 version 是 3
- 用户升级时 Room 检测到版本不匹配

### 测试建议
- [ ] 安装新版本（versionCode 3）
- [ ] 从旧版本（versionCode 2）升级
- [ ] 验证数据库迁移成功（现有任务状态 0→1）
- [ ] 验证数据不丢失
- [ ] 验证崩溃报告界面正常工作

---
**关联 PR**: #50