### PR TITLE
chore: 升级版本码到 4（包含 fallback 容错机制）

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.stupidbeauty.joyman"
         minSdk 24
         targetSdk 34
-        versionCode 3
-        versionName "2026.4.4"
+        versionCode 4
+        versionName "2026.4.5"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## 变更内容

升级应用版本号，包含 fallback 容错机制。

### 版本更新
- **versionCode**: 3 → 4
- **versionName**: 2026.4.4 → 2026.4.5

### 包含修复
- ✅ PR #52: `.fallbackToDestructiveMigrationOnDowngrade()`
- ✅ Room 官方推荐的容错方案
- ✅ 解决 status 字段默认值验证问题
- ✅ 优先使用 MIGRATION_2_3 进行无损迁移
- ✅ Schema 验证失败时自动重建数据库（兜底）

### 为什么需要 versionCode 4？
PR #52 合并后忘记更新 versionCode，导致：
- CI 编译的 APK 还是 versionCode 3
- 用户安装的也是旧版本
- 没有 fallback 容错机制
- 仍然遇到默认值验证失败

### 测试建议
- [ ] 安装新版本（versionCode 4）
- [ ] 从旧版本（versionCode 2 或 3）升级
- [ ] 验证数据库迁移成功
- [ ] 验证数据不丢失
- [ ] 验证崩溃报告界面正常工作

---
**关联 PR**: #52