### PR TITLE
feat: 添加详细调试日志排查 project_id 过滤问题

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/api/JoyManApiService.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/api/JoyManApiService.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 import fi.iki.elonen.NanoHTTPD;
 
 /**
- * JoyMan REST API 服务器
+ * JoyMan REST API 服务器 - 带详细调试日志
  */
 public class JoyManApiService extends NanoHTTPD {
     private static final String TAG = "JoyManApiService";
@@ -212,6 +212,14 @@ public class JoyManApiService extends NanoHTTPD {
         Method method = session.getMethod();
 
         logUtils.i(TAG, "Request: " + method + " " + uri + " from " + session.getRemoteIpAddress());
+        
+        // 🔍 新增：打印完整的原始 URI 和 Query String
+        logUtils.d(TAG, "serve: === 原始请求信息 START ===");
+        logUtils.d(TAG, "serve: Raw URI: " + session.getUri());
+        logUtils.d(TAG, "serve: Query String: " + session.getQuery());
+        logUtils.d(TAG, "serve: Method: " + method);
+        logUtils.d(TAG, "serve: Remote IP: " + session.getRemoteIpAddress());
+        logUtils.d(TAG, "serve: === 原始请求信息 END ===");
 
         // 打印所有请求头（用于调试）
         if (method.equals(Method.PUT) || method.equals(Method.POST)) {
@@ -516,7 +524,20 @@ public class JoyManApiService extends NanoHTTPD {
     private Response getIssues(IHTTPSession session) {
         logUtils.d(TAG, "getIssues: Listing all issues");
 
+        // 🔍 调试：打印完整的请求参数
+        logUtils.d(TAG, "getIssues: === 参数调试 START ===");
+        logUtils.d(TAG, "getIssues: Query String: " + session.getQuery());
+        logUtils.d(TAG, "getIssues: URI: " + session.getUri());
+        
         Map<String, String> params = session.getParms();
+        logUtils.d(TAG, "getIssues: params size: " + (params != null ? params.size() : 0));
+        if (params != null) {
+            for (Map.Entry<String, String> entry : params.entrySet()) {
+                logUtils.d(TAG, "getIssues: params[" + entry.getKey() + "] = " + entry.getValue());
+            }
+        }
+        logUtils.d(TAG, "getIssues: params.get(\"project_id\") = " + (params != null ? params.get("project_id") : "params is null"));
+        logUtils.d(TAG, "getIssues: === 参数调试 END ===");
         
         int limit = parseIntSafe(params.get("limit"), 25);
         int offset = parseIntSafe(params.get("offset"), 0);

--- a/app/src/main/java/com/stupidbeauty/joyman/api/JoyManApiService.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/api/JoyManApiService.java
@@ -216,7 +216,16 @@ public class JoyManApiService extends NanoHTTPD {
         // 🔍 新增：打印完整的原始 URI 和 Query String
         logUtils.d(TAG, "serve: === 原始请求信息 START ===");
         logUtils.d(TAG, "serve: Raw URI: " + session.getUri());
-        logUtils.d(TAG, "serve: Query String: " + session.getQuery());
+        
+        // NanoHTTPD 没有 getQuery() 方法，需要从 URI 中解析
+        String fullUri = session.getUri();
+        String queryString = "";
+        int queryIndex = fullUri.indexOf('?');
+        if (queryIndex >= 0) {
+            queryString = fullUri.substring(queryIndex + 1);
+        }
+        logUtils.d(TAG, "serve: Query String: " + queryString);
+        
         logUtils.d(TAG, "serve: Method: " + method);
         logUtils.d(TAG, "serve: Remote IP: " + session.getRemoteIpAddress());
         logUtils.d(TAG, "serve: === 原始请求信息 END ===");
@@ -526,8 +535,16 @@ public class JoyManApiService extends NanoHTTPD {
 
         // 🔍 调试：打印完整的请求参数
         logUtils.d(TAG, "getIssues: === 参数调试 START ===");
-        logUtils.d(TAG, "getIssues: Query String: " + session.getQuery());
-        logUtils.d(TAG, "getIssues: URI: " + session.getUri());
+        
+        // 从 URI 中解析 query string
+        String fullUri = session.getUri();
+        String queryString = "";
+        int queryIndex = fullUri.indexOf('?');
+        if (queryIndex >= 0) {
+            queryString = fullUri.substring(queryIndex + 1);
+        }
+        logUtils.d(TAG, "getIssues: Query String: " + queryString);
+        logUtils.d(TAG, "getIssues: URI: " + fullUri);
         
         Map<String, String> params = session.getParms();
         logUtils.d(TAG, "getIssues: params size: " + (params != null ? params.size() : 0));


### PR DESCRIPTION
## 🐛 问题描述

JoyMan API 的 `get_issues_list` 接口在传入 `project_id` 参数后，日志显示 `project_id=null`，导致返回所有项目的任务而不是指定项目的任务。

**日志证据：**
```
14:15:22.273 D/JoyManApiService: getIssues: Filters - project_id=null, status_id=null...
```

## 🔍 调试方案

本次 PR 添加了详细的调试日志，用于排查参数解析链路：

### 新增日志点：
1. **`serve()` 方法**：打印原始请求信息
   - Raw URI（完整 URI）
   - Query String（URL 查询字符串）
   - Method（HTTP 方法）
   - Remote IP（客户端 IP）

2. **`getIssues()` 方法**：打印完整的参数解析过程
   - params size（参数数量）
   - 每个参数的键值对
   - 特别关注 `params.get("project_id")` 的值
   - 最终过滤使用的 `projectId` 值

## 📋 测试步骤

1. 部署此分支到 JoyMan 应用
2. 调用 `get_issues_list` 工具，传入 `project_id=751095624566`
3. 查看新的日志输出
4. 确认 `project_id` 是在哪个环节丢失的

## 🎯 预期结果

通过详细日志定位问题：
- 如果 Query String 中有 `project_id` → 说明是 NanoHTTPD 的 `getParms()` 解析问题
- 如果 Query String 中没有 `project_id` → 说明是调用方没有传递参数
- 如果 params 中有但值为 null → 说明类型转换或过滤逻辑有问题

---
**相关任务：** #756294474915 (修复 JoyMan project_id 参数未生效问题)