### PR TITLE
fix: 修复 comments 表迁移脚本 NOT NULL 约束导致的崩溃

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/data/database/AppDatabase.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/data/database/AppDatabase.java
@@ -152,12 +152,13 @@ public abstract class AppDatabase extends RoomDatabase {
             LogUtils.getInstance().d(TAG, "MIGRATION_4_5: START - Creating comments table for comment feature");
             
             // 创建 comments 表
+            // 注意：content 和 author 允许为 NULL，与 Comment 实体类保持一致
             database.execSQL(
                 "CREATE TABLE IF NOT EXISTS `comments` (" +
                 "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
                 "`issue_id` INTEGER NOT NULL, " +
-                "`content` TEXT NOT NULL, " +
-                "`author` TEXT NOT NULL, " +
+                "`content` TEXT, " +
+                "`author` TEXT, " +
                 "`created_on` INTEGER NOT NULL, " +
                 "FOREIGN KEY(`issue_id`) REFERENCES `tasks`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
             );


### PR DESCRIPTION
## 🐛 修复内容

### 问题描述
应用启动时发生崩溃，错误信息：
```
java.lang.IllegalStateException: Migration didn't properly handle: comments
Expected: content=Column{notNull=false}, author=Column{notNull=false}
Found: content=Column{notNull=true}, author=Column{notNull=true}
```

### 根本原因
`MIGRATION_4_5` 迁移脚本中 `content` 和 `author` 字段错误地定义了 `NOT NULL` 约束，但 `Comment` 实体类中这两个字段没有 `@ColumnInfo(notNull = true)` 注解，导致 Room 验证失败。

### 解决方案
修改 `AppDatabase.java` 中的 `MIGRATION_4_5` 迁移脚本：
- **修改前**: `content TEXT NOT NULL`, `author TEXT NOT NULL`
- **修改后**: `content TEXT`, `author TEXT`（允许为 NULL）

### 影响范围
- ✅ 修复数据库升级时的崩溃问题
- ✅ 确保迁移脚本与实体类定义一致
- ✅ 不影响现有数据（新表创建时才生效）

---

## 📦 本 PR 包含的提交

1. **feat**: 添加 Comment 评论实体类 (`0c0dccd`)
2. **feat**: 添加 CommentDao 评论数据访问对象 (`8ca8894`)
3. **feat**: 更新数据库版本到 v5，添加 Comment 表支持 (`c0d0786`)
4. **feat**: 创建 CommentAdapter 评论列表适配器 (`07498b7`)
5. **feat**: 添加评论项布局文件 item_comment.xml (`cf72657`)
6. **feat**: 在任务详情页添加评论功能 UI (`8d78d9f`)
7. **feat**: 在 TaskDetailActivity 实现评论功能逻辑 (`49a630a`)
8. **fix**: 修改评论列表排序为正序（时间早的在上，最新的在下）(`65c4705`)
9. **fix**: 修改 CommentAdapter 添加评论到列表末尾 (`2135ae0`)
10. **fix**: 在 TaskViewModel 中添加 getAppDatabase 方法 (`34306f8`)
11. **fix**: 在 Comment 实体中添加 @ColumnInfo 注解明确列名 (`e0cc1ad`)
12. **fix**: 修复 comments 表迁移脚本中 content 和 author 字段的 NOT NULL 约束 (`b37db4d`) ← **最新修复**

---

## 🧪 测试建议

- [ ] 全新安装应用，验证评论功能正常
- [ ] 从旧版本升级，验证数据库迁移成功，不崩溃
- [ ] 发表评论，验证保存和显示正常
- [ ] 查看评论列表，验证按时间正序排列

---

## 🔗 关联任务

- Closes #764745094928 [界面] 实现任务评论功能
- Related to #764782076622 create_github_commit 工具出错时提示检查分支是否存在

---

**开发者**: 太极美术工程狮狮长  
**分支**: `feature/comment` → `master`  
**CI 状态**: 等待构建中...