### PR TITLE
fix: improve notification visibility for ApiForegroundService

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/api/ApiForegroundService.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/api/ApiForegroundService.java
@@ -141,7 +141,7 @@ public class ApiForegroundService extends Service {
             NotificationChannel channel = new NotificationChannel(
                 CHANNEL_ID,
                 "JoyMan API 服务",
-                NotificationManager.IMPORTANCE_LOW
+                NotificationManager.IMPORTANCE_DEFAULT
             );
             channel.setDescription("REST API 服务运行状态通知");
             channel.setShowBadge(false);
@@ -175,12 +175,14 @@ public class ApiForegroundService extends Service {
         NotificationCompat.Builder builder = new NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("JoyMan API 服务")
             .setContentText("REST API 正在运行于端口 " + DEFAULT_PORT)
-            .setSmallIcon(android.R.drawable.ic_dialog_info) // 使用系统默认图标
+            .setSmallIcon(android.R.drawable.ic_menu_manage) // 使用系统默认图标
             .setContentIntent(pendingIntent)
             .setOngoing(true)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
-            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setOnlyAlertOnce(true);
         
         Notification notification = builder.build();
         logUtils.d(TAG, "createNotification: Notification created");


### PR DESCRIPTION
## 问题描述
JoyMan 的 `ApiForegroundService` 前台服务通知未能在状态栏正常显示。

## 修复内容
- 将通知图标改为系统服务图标 `android.R.drawable.ic_menu_manage`
- 将通知渠道重要性从 `IMPORTANCE_LOW` 提升至 `IMPORTANCE_DEFAULT`
- 添加 `setOnlyAlertOnce(true)` 减少重复提醒
- 明确设置 `setCategory(CATEGORY_SERVICE)`

## 测试
编译成功，APK 已生成。请在努比亚设备上测试通知栏是否正常显示 "JoyMan API 服务" 通知。