### PR TITLE
fix: add MANAGE_EXTERNAL_STORAGE permission request flow

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/MainActivity.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/MainActivity.java
@@ -2,6 +2,8 @@ package com.stupidbeauty.joyman;
 
 import android.Manifest;
 import android.content.Intent;
+import android.net.Uri;
+import android.provider.Settings;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
@@ -54,6 +56,7 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
     private static final String TAG = "MainActivity";
     private static final int FTP_SERVER_PORT = 2122;
     private static final int NOTIFICATION_PERMISSION_REQUEST_CODE = 1001;
+    private static final int STORAGE_PERMISSION_REQUEST_CODE = 1002;
     
     private static MainActivity instance;
     
@@ -95,6 +98,9 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
         
         // 检查通知权限（Android 13+）
         checkNotificationPermission();
+        
+        // 检查存储权限（Android 11+）
+        checkAndRequestStoragePermission();
     }
     
     @Override
@@ -375,6 +381,41 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
     /**
      * 检查通知权限（Android 13+）
      */
+    /**
+     * 检查并请求存储权限（Android 11+）
+     * 注意：MANAGE_EXTERNAL_STORAGE 不能通过 requestPermissions 请求，
+     * 必须跳转到系统设置页面由用户手动授权。
+     */
+    private void checkAndRequestStoragePermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            if (!android.os.Environment.isExternalStorageManager()) {
+                logUtils.w(TAG, "checkAndRequestStoragePermission: Permission not granted, showing dialog...");
+                
+                new AlertDialog.Builder(this)
+                    .setTitle("需要文件管理权限")
+                    .setMessage("JoyMan 需要「管理所有文件」权限才能将日志写入外部存储。\n\n请点击「确定」跳转到系统设置页面进行授权。")
+                    .setPositiveButton("确定", (dialog, which) -> {
+                        openStoragePermissionSettings();
+                    })
+                    .setNegativeButton("取消", null)
+                    .show();
+            } else {
+                logUtils.d(TAG, "checkAndRequestStoragePermission: Permission already granted");
+            }
+        }
+    }
+    
+    /**
+     * 打开系统设置页面，请求 MANAGE_EXTERNAL_STORAGE 权限
+     */
+    private void openStoragePermissionSettings() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Intent intent = new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
+            intent.setData(Uri.parse("package:" + getPackageName()));
+            startActivity(intent);
+        }
+    }
+
     private void checkNotificationPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)

--- a/app/src/main/java/com/stupidbeauty/joyman/util/LogUtils.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/util/LogUtils.java
@@ -105,6 +105,16 @@ public class LogUtils {
             return null;
         }
     }
+    
+    private boolean checkExternalStoragePermission() {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+            // Android 11+ uses MANAGE_EXTERNAL_STORAGE
+            return android.os.Environment.isExternalStorageManager();
+        } else {
+            // Android 10 and below use WRITE_EXTERNAL_STORAGE
+            return true; // Assuming permission is granted via manifest/request
+        }
+    }
     }
     
     private boolean checkExternalStoragePermission() {

--- a/app/src/main/java/com/stupidbeauty/joyman/util/LogUtils.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/util/LogUtils.java
@@ -1,9 +1,6 @@
 package com.stupidbeauty.joyman.util;
 
 import android.os.Environment;
-import android.content.Context;
-import android.provider.Settings;
-import android.net.Uri;
 import android.util.Log;
 
 import java.io.File;
@@ -23,7 +20,7 @@ import java.util.concurrent.Executors;
  * 支持同时输出到 Logcat 和文件
  * 
  * @author 太极美术工程狮狮长
- * @version 1.1.0
+ * @version 1.2.0
  * @since 2026-04-01
  */
 public class LogUtils {
@@ -72,7 +69,11 @@ public class LogUtils {
         if (!currentHourKey.equals(lastHourKey)) {
             lastHourKey = currentHourKey;
             File logDir = getLogDirectory();
-            currentLogFile = new File(logDir, LOG_FILE_PREFIX + dateStr + "_" + hourStr + LOG_FILE_SUFFIX).getAbsolutePath();
+            if (logDir != null) {
+                currentLogFile = new File(logDir, LOG_FILE_PREFIX + dateStr + "_" + hourStr + LOG_FILE_SUFFIX).getAbsolutePath();
+            } else {
+                currentLogFile = null;
+            }
         }
     }
     
@@ -115,18 +116,6 @@ public class LogUtils {
             return true; // Assuming permission is granted via manifest/request
         }
     }
-    }
-    
-    private boolean checkExternalStoragePermission() {
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
-            // Android 11+ uses MANAGE_EXTERNAL_STORAGE
-            return android.os.Environment.isExternalStorageManager();
-        } else {
-            // Android 10 and below use WRITE_EXTERNAL_STORAGE
-            return true; // Assuming permission is granted via manifest/request
-        }
-    }
-    }
     
     /**
      * 写入日志到文件
@@ -135,6 +124,11 @@ public class LogUtils {
         executorService.execute(() -> {
             // 检查是否需要切换日志文件（跨小时情况）
             updateCurrentLogFile();
+            
+            if (currentLogFile == null) {
+                Log.e(TAG, "Cannot write to file: currentLogFile is null");
+                return;
+            }
             
             String timestamp = timeFormat.format(new Date());
             StringBuilder logBuilder = new StringBuilder();
@@ -225,6 +219,7 @@ public class LogUtils {
      * 获取日志目录路径
      */
     public String getLogDirectoryPath() {
-        return getLogDirectory().getAbsolutePath();
+        File dir = getLogDirectory();
+        return dir != null ? dir.getAbsolutePath() : "N/A";
     }
 }

--- a/app/src/main/java/com/stupidbeauty/joyman/util/LogUtils.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/util/LogUtils.java
@@ -80,7 +80,7 @@ public class LogUtils {
      * 获取日志目录
      */
     private File getLogDirectory() {
-        // Priority 1: Try public Download directory (requires MANAGE_EXTERNAL_STORAGE on Android 11+)
+        // Try public Download directory (requires MANAGE_EXTERNAL_STORAGE on Android 11+)
         File publicLogDir = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), LOG_DIR_NAME);
         
         if (publicLogDir.exists()) {
@@ -98,17 +98,13 @@ public class LogUtils {
                 return publicLogDir;
             } else {
                 Log.e(TAG, "❌ Failed to create public log directory even with permission.");
+                return null;
             }
         } else {
-            Log.w(TAG, "⚠️ No external storage permission. Falling back to private directory.");
+            Log.w(TAG, "⚠️ No external storage permission. Log file writing will be disabled until permission is granted.");
+            return null;
         }
-        
-        // Fallback: Use app's private external files directory (no permission needed)
-        // Note: This requires a Context, which LogUtils doesn't have.
-        // For now, we will return null and let writeToFile handle the error gracefully.
-        // In a real app, LogUtils should be initialized with a Context in Application.onCreate().
-        Log.e(TAG, "❌ Cannot access any log directory. Please grant storage permissions in Settings.");
-        return null;
+    }
     }
     
     private boolean checkExternalStoragePermission() {


### PR DESCRIPTION
## 问题描述
LogUtils 无法在 `/sdcard/Download/joyman_logs/` 创建目录，因为 Android 11+ 需要 `MANAGE_EXTERNAL_STORAGE` 权限。

## 修复内容
1. **MainActivity.java**: 
   - 添加 `checkAndRequestStoragePermission()` 方法
   - 在 `onCreate()` 中检查权限，如果不足则弹出对话框引导用户去系统设置页面授权
2. **LogUtils.java**: 
   - 移除 fallback 到私有目录的逻辑
   - 严格使用公共 Download 目录
   - 如果权限不足，返回 null（writeToFile 会处理并记录日志）

## 测试
请安装新版本后：
1. 打开应用，应该会弹出对话框请求"管理所有文件"权限
2. 点击"确定"跳转到系统设置页面进行授权
3. 授权后返回应用，检查 `/sdcard/Download/joyman_logs/` 目录是否有日志文件生成