### PR TITLE
fix: add MANAGE_EXTERNAL_STORAGE permission request

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/api/ApiForegroundService.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/api/ApiForegroundService.java
@@ -66,6 +66,18 @@ public class ApiForegroundService extends Service {
         logUtils = LogUtils.getInstance();
         logUtils.i(TAG, "onCreate: API Foreground Service created");
         
+        // 检查存储权限并启动 MainActivity
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            if (!android.os.Environment.isExternalStorageManager()) {
+                logUtils.w(TAG, "Storage permission not granted, starting MainActivity to request permission");
+                Intent mainIntent = new Intent(this, MainActivity.class);
+                mainIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                startActivity(mainIntent);
+            } else {
+                logUtils.d(TAG, "Storage permission already granted");
+            }
+        }
+        
         // 创建通知渠道（必须在显示通知前创建）
         createNotificationChannel();
     }


### PR DESCRIPTION
## 问题描述
Android 11+ 需要 MANAGE_EXTERNAL_STORAGE 权限才能将日志写入外部存储目录。

## 修复内容
1. **MainActivity.java**: 添加存储权限请求流程
2. **LogUtils.java**: 使用公共 Download 目录
3. **ApiForegroundService.java**: 在 onCreate 中检查权限并启动 MainActivity
4. **build.gradle**: 升级版本到 2026.5.10 (versionCode 8)

## 测试
1. 安装新版本 APK
2. 打开应用，应该会弹出权限对话框
3. 授予权限后检查日志目录