### PR TITLE
fix: add detailed debug logs for storage permission on Android 9

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/api/ApiForegroundService.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/api/ApiForegroundService.java
@@ -9,7 +9,6 @@ import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.Manifest;
 import android.os.Build;
 import android.os.IBinder;
 
@@ -69,12 +68,13 @@ public class ApiForegroundService extends Service {
         
         // 检查存储权限并启动 MainActivity（所有 Android 版本）
         if (!checkStoragePermission()) {
-            logUtils.w(TAG, "Storage permission not granted, starting MainActivity to request permission");
+            logUtils.w(TAG, "❌ Storage permission not granted on Android " + Build.VERSION.RELEASE + ", starting MainActivity to request permission");
             Intent mainIntent = new Intent(this, MainActivity.class);
             mainIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            mainIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(mainIntent);
         } else {
-            logUtils.d(TAG, "Storage permission already granted");
+            logUtils.d(TAG, "✅ Storage permission already granted on Android " + Build.VERSION.RELEASE);
         }
         
         // 创建通知渠道（必须在显示通知前创建）
@@ -145,7 +145,9 @@ public class ApiForegroundService extends Service {
             return true;
         } else {
             // Android 9 及以下需要 WRITE_EXTERNAL_STORAGE
-            return checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
+            boolean hasPermission = checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
+            logUtils.d(TAG, "checkStoragePermission on Android " + Build.VERSION.RELEASE + ": " + (hasPermission ? "granted" : "denied"));
+            return hasPermission;
         }
     }
 


### PR DESCRIPTION
## 问题描述
Android 9 (NX616J) 上存储权限请求未生效，日志无法写入。

## 修复内容
1. **ApiForegroundService.java**: 
   - 添加详细的调试日志，包含 Android 版本信息
   - 添加 `FLAG_ACTIVITY_CLEAR_TOP` 到 Intent 标志
   - 添加 emoji 指示符 (❌/✅) 便于调试
2. **checkStoragePermission()**: 添加 Android 9 的权限检查日志

## 测试
安装新版本后查看 logcat 输出：
- ❌ 如果看到 "Storage permission not granted"，说明权限未授予，MainActivity 应该会自动启动
- ✅ 如果看到 "Storage permission already granted"，说明权限已授予，但仍无法写入日志

请提供 logcat 输出以便进一步诊断。