### PR TITLE
feat: detect disabled notifications and guide user to system settings

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/api/ApiForegroundService.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/api/ApiForegroundService.java
@@ -5,16 +5,22 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
-import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Build;
-import android.os.IBinder;
+import android.provider.Settings;
+import android.service.notification.StatusBarNotification;
 import android.widget.Toast;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+
+import android.app.Service;
+import android.os.IBinder;
 
 import com.stupidbeauty.joyman.MainActivity;
 import com.stupidbeauty.joyman.util.LogUtils;
@@ -25,7 +31,6 @@ import com.stupidbeauty.joyman.util.LogUtils;
 public class ApiForegroundService extends Service {
     
     private static final String TAG = "ApiForegroundService";
-    // 使用新的渠道 ID 绕过 Android 9 的渠道重要性缓存
     private static final String CHANNEL_ID = "joyman_api_v2";
     private static final int NOTIFICATION_ID = 1001;
     private static final int DEFAULT_PORT = 8080;
@@ -41,12 +46,110 @@ public class ApiForegroundService extends Service {
             return;
         }
         logUtilsInfo(context, "🚀 Starting ApiForegroundService");
+        
+        // 检查通知是否被禁用
+        if (!isNotificationsEnabled(context)) {
+            logUtilsInfo(context, "❌ Notifications are DISABLED! Showing settings dialog...");
+            showNotificationSettingsDialog(context);
+            // 即使通知被禁用，也尝试启动服务（但用户可能看不到通知）
+        }
+        
         Intent intent = new Intent(context, ApiForegroundService.class);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             context.startForegroundService(intent);
         } else {
             context.startService(intent);
         }
+    }
+    
+    /**
+     * 检查应用的通知权限是否被用户或系统禁用
+     */
+    public static boolean isNotificationsEnabled(Context context) {
+        // Android 7.0+ 可以使用 areNotificationsEnabled()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            NotificationManagerCompat manager = NotificationManagerCompat.from(context);
+            boolean enabled = manager.areNotificationsEnabled();
+            
+            LogUtils logUtils = LogUtils.getInstance();
+            if (logUtils != null) {
+                logUtils.d(TAG, "isNotificationsEnabled: " + enabled);
+                
+                if (!enabled) {
+                    logUtils.e(TAG, "❌ NOTIFICATIONS ARE DISABLED!");
+                    logUtils.e(TAG, "💡 User must manually enable in Settings → Apps → JoyMan → Notifications");
+                }
+            }
+            
+            return enabled;
+        }
+        
+        // Android 6.0 及以下默认启用通知
+        return true;
+    }
+    
+    /**
+     * 显示通知设置对话框，引导用户到系统设置页面
+     */
+    public static void showNotificationSettingsDialog(Context context) {
+        LogUtils logUtils = LogUtils.getInstance();
+        if (logUtils != null) {
+            logUtils.w(TAG, "📢 Showing notification settings dialog...");
+        }
+        
+        new AlertDialog.Builder(context)
+            .setTitle("⚠️ 通知权限已关闭")
+            .setMessage(
+                "JoyMan 需要通知权限来保持 API 服务在前台运行。\n\n" +
+                "检测到您的设备已关闭 JoyMan 的通知权限，这会导致：\n" +
+                "• ❌ 无法看到 API 服务运行状态\n" +
+                "• ❌ 服务可能被系统自动杀死\n" +
+                "• ❌ 日志功能可能受影响\n\n" +
+                "请点击「去设置」手动开启通知权限：\n" +
+                "1. 点击「允许通知」开关\n" +
+                "2. 确保「JoyMan API 服务」渠道已启用\n" +
+                "3. 将重要性设置为「高」或「紧急」\n\n" +
+                "💡 提示：这是 Android 系统的安全机制，需要用户手动授权。"
+            )
+            .setPositiveButton("⚙️ 去设置", (dialog, which) -> {
+                // 打开应用通知设置页面
+                Intent intent = new Intent();
+                intent.setAction(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
+                intent.putExtra(Settings.EXTRA_APP_PACKAGE, context.getPackageName());
+                intent.putExtra(Settings.EXTRA_CHANNEL_ID, CHANNEL_ID);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                context.startActivity(intent);
+                
+                if (logUtils != null) {
+                    logUtils.i(TAG, "✅ Opened notification settings page");
+                }
+            })
+            .setNegativeButton("❌ 取消", (dialog, which) -> {
+                if (logUtils != null) {
+                    logUtils.w(TAG, "⚠️ User declined to open notification settings");
+                }
+                Toast.makeText(context, 
+                    "⚠️ 通知未开启，API 服务可能无法正常运行", 
+                    Toast.LENGTH_LONG).show();
+            })
+            .setNeutralButton("❓ 为什么需要通知？", (dialog, which) -> {
+                // 显示详细说明
+                new AlertDialog.Builder(context)
+                    .setTitle("为什么需要通知权限？")
+                    .setMessage(
+                        "Android 系统要求前台服务必须显示持久通知，这是为了：\n\n" +
+                        "✅ 透明度：让用户知道有服务在后台运行\n" +
+                        "✅ 可控性：用户可以随时通过通知管理或停止服务\n" +
+                        "✅ 电池优化：系统可以智能管理后台服务的电量消耗\n\n" +
+                        "JoyMan 的 API 服务需要持续运行以提供 REST API 接口，" +
+                        "因此必须显示通知来告知用户服务正在运行。\n\n" +
+                        "🔒 隐私说明：该通知不会收集或泄露任何个人信息。"
+                    )
+                    .setPositiveButton("明白了", null)
+                    .show();
+            })
+            .setCancelable(false)
+            .show();
     }
     
     public static void stop(Context context) {
@@ -73,6 +176,12 @@ public class ApiForegroundService extends Service {
         logUtils = LogUtils.getInstance();
         logUtils.i(TAG, "✅ onCreate: API Foreground Service on Android " + Build.VERSION.RELEASE);
         
+        // 再次检查通知状态
+        if (!isNotificationsEnabled(this)) {
+            logUtils.e(TAG, "❌ Notifications still disabled in onCreate!");
+            Toast.makeText(this, "⚠️ 通知权限已关闭，请在设置中开启", Toast.LENGTH_LONG).show();
+        }
+        
         if (!checkStoragePermission()) {
             logUtils.w(TAG, "❌ Storage permission not granted");
             Intent mainIntent = new Intent(this, MainActivity.class);
@@ -80,7 +189,6 @@ public class ApiForegroundService extends Service {
             startActivity(mainIntent);
         }
         
-        // 删除旧渠道并创建新渠道
         deleteNotificationChannel();
         createNotificationChannel();
         checkNotificationChannelStatus();
@@ -96,7 +204,14 @@ public class ApiForegroundService extends Service {
         isRunning = true;
         logUtils.i(TAG, "▶️ Starting API foreground service");
         
-        // Toast 备用通知
+        // 最终检查：如果通知仍被禁用，显示 Toast 警告
+        if (!isNotificationsEnabled(this)) {
+            logUtils.e(TAG, "⚠️️⚠️ CRITICAL: Notifications are DISABLED! Service may be killed by system.");
+            Toast.makeText(this, 
+                "⚠️ 通知权限未开启！\n请下拉通知栏查看设置提示，或到设置中手动开启", 
+                Toast.LENGTH_LONG).show();
+        }
+        
         Toast.makeText(this, "JoyMan API 服务已启动", Toast.LENGTH_LONG).show();
         logUtils.i(TAG, "💬 Showing Toast");
         
@@ -105,6 +220,11 @@ public class ApiForegroundService extends Service {
         logUtils.i(TAG, "🔔 Calling startForeground");
         startForeground(NOTIFICATION_ID, notification);
         logUtils.i(TAG, "✅ startForeground() called - service is FOREGROUND");
+        
+        // 如果通知被禁用，1 秒后再次提醒
+        if (!isNotificationsEnabled(this)) {
+            postDelayedNotificationReminder();
+        }
         
         try {
             apiService = new JoyManApiService(this, DEFAULT_PORT);
@@ -119,6 +239,44 @@ public class ApiForegroundService extends Service {
         }
         
         return START_STICKY;
+    }
+    
+    /**
+     * 延迟显示通知提醒
+     */
+    private void postDelayedNotificationReminder() {
+        new android.os.Handler(getMainLooper()).postDelayed(() -> {
+            if (!isNotificationsEnabled(ApiForegroundService.this)) {
+                logUtils.e(TAG, "⚠️ Reminder: Notifications still disabled!");
+                
+                // 尝试发送一个高优先级的测试通知（可能会被系统阻止，但值得一试）
+                try {
+                    NotificationManager manager = getSystemService(NotificationManager.class);
+                    if (manager != null) {
+                        NotificationCompat.Builder reminderBuilder = new NotificationCompat.Builder(this, CHANNEL_ID)
+                            .setContentTitle("⚠️ 请开启通知权限")
+                            .setContentText("点击此处进入设置页面开启 JoyMan 的通知权限")
+                            .setSmallIcon(android.R.drawable.ic_dialog_alert)
+                            .setPriority(NotificationCompat.PRIORITY_MAX)
+                            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+                            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                            .setAutoCancel(true)
+                            .setContentIntent(PendingIntent.getActivity(
+                                this, 0,
+                                new Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                                    .putExtra(Settings.EXTRA_APP_PACKAGE, getPackageName())
+                                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+                            ));
+                        
+                        manager.notify(8888, reminderBuilder.build());
+                        logUtils.i(TAG, "📢 Sent reminder notification (ID: 8888)");
+                    }
+                } catch (Exception e) {
+                    logUtils.e(TAG, "❌ Failed to send reminder notification", e);
+                }
+            }
+        }, 1000); // 1 秒后检查
     }
     
     @Override
@@ -137,14 +295,10 @@ public class ApiForegroundService extends Service {
         return null;
     }
     
-    /**
-     * 删除旧的通知渠道（解决 Android 9 渠道重要性缓存问题）
-     */
     private void deleteNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationManager manager = getSystemService(NotificationManager.class);
             if (manager != null) {
-                // 删除新旧所有可能的渠道
                 manager.deleteNotificationChannel("joyman_api_channel");
                 manager.deleteNotificationChannel(CHANNEL_ID);
                 logUtils.d(TAG, "🗑️ Deleted old notification channels");
@@ -164,6 +318,11 @@ public class ApiForegroundService extends Service {
                         " (4=HIGH ✓, 3=DEFAULT, 2=LOW ✗)");
                     logUtils.i(TAG, "   - Lockscreen Visibility: " + channel.getLockscreenVisibility());
                     logUtils.i(TAG, "   - Show Badge: " + channel.canShowBadge());
+                    
+                    // 检查渠道本身是否被用户禁用
+                    if (channel.getImportance() == NotificationManager.IMPORTANCE_NONE) {
+                        logUtils.e(TAG, "❌ CRITICAL: Channel importance is NONE! User may have disabled this channel.");
+                    }
                     
                     postTestNotification(manager);
                 } else {
@@ -211,11 +370,10 @@ public class ApiForegroundService extends Service {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             logUtils.d(TAG, "📺 Creating notification channel (ID: " + CHANNEL_ID + ")...");
             
-            // 使用 IMPORTANCE_HIGH 确保通知显示
             NotificationChannel channel = new NotificationChannel(
                 CHANNEL_ID,
                 "JoyMan API 服务",
-                NotificationManager.IMPORTANCE_HIGH  // 4 = HIGH
+                NotificationManager.IMPORTANCE_HIGH
             );
             channel.setDescription("REST API 服务运行状态通知 - 保持服务在前台运行");
             channel.setShowBadge(true);
@@ -229,7 +387,6 @@ public class ApiForegroundService extends Service {
                 manager.createNotificationChannel(channel);
                 logUtils.i(TAG, "✅ Notification channel created with HIGH importance (4)");
                 
-                // 验证设置是否生效
                 NotificationChannel createdChannel = manager.getNotificationChannel(CHANNEL_ID);
                 if (createdChannel != null) {
                     if (createdChannel.getImportance() == NotificationManager.IMPORTANCE_HIGH) {


### PR DESCRIPTION
## 问题描述
Android 9 (努比亚 JOS) 上通知栏通知不显示，即使渠道重要性已正确设置为 HIGH。

**根本原因**：
- 用户在系统设置中**手动关闭了 JoyMan 的应用级通知权限**
- 日志显示：`通知：关闭`（在应用信息页面）
- 即使代码设置了 `IMPORTANCE_HIGH`，系统会在应用级别阻止所有通知

## 修复内容
1. **ApiForegroundService.java**: 
   - ✅ 添加 `isNotificationsEnabled()` 方法检测应用通知是否被禁用
   - ✅ 在启动服务前自动检查，如果禁用则弹出 AlertDialog
   - ✅ 提供"去设置"按钮，直接跳转到系统通知设置页面
   - ✅ 添加"为什么需要通知？"帮助说明
   - ✅ 多重提醒机制（Toast + 延迟提醒通知）
   - ✅ 详细的日志记录通知状态

## 技术实现
```java
// 检测通知权限
if (!isNotificationsEnabled(context)) {
    showNotificationSettingsDialog(context); // 引导用户到设置
}
```

## 用户体验流程
1. 打开应用 → 检测到通知被禁用
2. 弹出对话框："⚠️ 通知权限已关闭"
3. 用户点击"去设置" → 自动跳转到 JoyMan 通知设置页面
4. 用户开启"允许通知"开关
5. 返回应用 → 通知正常显示

## 测试步骤
1. 安装新版本 APK
2. 打开应用（确保通知权限已关闭）
3. 应该看到"⚠️ 通知权限已关闭"对话框
4. 点击"去设置"，开启通知权限
5. 返回应用，应该能看到：
   - Toast: "JoyMan API 服务已启动"
   - 通知栏: "JoyMan API 服务" 通知
   - 通知栏: "JoyMan 测试通知" (ID: 9999)

## 截图说明
用户之前提供的截图显示：
```
应用信息 → 通知：关闭 ← 这就是问题所在！
```

此修复将引导用户手动开启该开关。