### PR TITLE
fix: move notification check to MainActivity to avoid Theme.AppCompat crash

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/MainActivity.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/MainActivity.java
@@ -7,6 +7,7 @@ import android.provider.Settings;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -29,6 +30,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.stupidbeauty.builtinftp.BuiltinFtpServer;
+import com.stupidbeauty.joyman.api.ApiForegroundService;
 import com.stupidbeauty.joyman.data.database.entity.Project;
 import com.stupidbeauty.joyman.data.database.entity.Task;
 import com.stupidbeauty.joyman.listener.BuiltinFtpServerErrorListener;
@@ -43,13 +45,8 @@ import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 
-
 /**
  * JoyMan 主界面 - 任务列表展示
- * 
- * @author 太极美术工程狮狮长
- * @version 3.1.0
- * @since 2026-04-01
  */
 public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTaskClickListener, ProjectAdapter.OnProjectClickListener {
     
@@ -101,6 +98,29 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
         
         // 检查通知权限（Android 13+）
         checkNotificationPermission();
+        
+        // 延迟检查应用级通知是否被禁用（500ms 后）
+        new Handler(getMainLooper()).postDelayed(() -> {
+            checkAppNotificationsEnabled();
+        }, 500);
+    }
+    
+    /**
+     * 检查应用的通知权限是否被禁用
+     */
+    private void checkAppNotificationsEnabled() {
+        if (isFinishing()) {
+            return;
+        }
+        
+        boolean enabled = ApiForegroundService.isNotificationsEnabled(this);
+        
+        if (!enabled) {
+            logUtils.e(TAG, "❌ App notifications are DISABLED! Showing dialog...");
+            ApiForegroundService.showNotificationSettingsDialog(this);
+        } else {
+            logUtils.d(TAG, "✅ App notifications are enabled");
+        }
     }
     
     @Override
@@ -111,9 +131,6 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
         }
     }
     
-    /**
-     * 获取 MainActivity 实例（用于 Service 请求权限）
-     */
     public static MainActivity getInstance() {
         return instance;
     }
@@ -177,10 +194,8 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
             projectSpinnerAdapter.notifyDataSetChanged();
         });
         
-        // 观察所有任务
         taskViewModel.getAllTasks().observe(this, tasks -> {
             if (tasks != null && selectedProject == null && !isSearching) {
-                // 过滤掉已关闭的任务
                 List<Task> filteredTasks = tasks.stream()
                     .filter(task -> task.getStatus() != Task.STATUS_CLOSED)
                     .collect(java.util.stream.Collectors.toList());
@@ -202,7 +217,6 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
         layout.setOrientation(LinearLayout.VERTICAL);
         layout.setPadding(50, 50, 50, 50);
         
-        // 任务标题输入框
         EditText editTextTitle = new EditText(this);
         editTextTitle.setHint(R.string.new_task_hint);
         editTextTitle.setLayoutParams(new LinearLayout.LayoutParams(
@@ -210,7 +224,6 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
             LinearLayout.LayoutParams.WRAP_CONTENT));
         layout.addView(editTextTitle);
         
-        // 任务描述输入框
         EditText editTextDescription = new EditText(this);
         editTextDescription.setHint("任务描述（可选）");
         editTextDescription.setLayoutParams(new LinearLayout.LayoutParams(
@@ -222,7 +235,6 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
         editTextDescription.setGravity(android.view.Gravity.TOP);
         layout.addView(editTextDescription);
         
-        // 项目选择器
         Spinner spinnerProject = new Spinner(this);
         spinnerProject.setLayoutParams(new LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.MATCH_PARENT,
@@ -268,7 +280,6 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
                         projectId = projectIds.get(selectedPosition);
                     }
                     
-                    // 创建任务（支持描述）
                     long taskId = taskViewModel.createTask(title, description);
                     
                     if (projectId != null) {
@@ -335,7 +346,6 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
     private void loadAllTasks() {
         taskViewModel.getAllTasks().observe(this, tasks -> {
             if (tasks != null) {
-                // 过滤掉已关闭的任务
                 List<Task> filteredTasks = tasks.stream()
                     .filter(task -> task.getStatus() != Task.STATUS_CLOSED)
                     .collect(java.util.stream.Collectors.toList());
@@ -348,7 +358,6 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
     private void loadTasksByProject(long projectId) {
         taskViewModel.getTasksByProject(projectId).observe(this, tasks -> {
             if (tasks != null) {
-                // 过滤掉已关闭的任务
                 List<Task> filteredTasks = tasks.stream()
                     .filter(task -> task.getStatus() != Task.STATUS_CLOSED)
                     .collect(java.util.stream.Collectors.toList());
@@ -378,16 +387,12 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
         android.util.Log.d(TAG, "FTP server started on port " + FTP_SERVER_PORT);
     }
     
-    /**
-     * 检查并请求存储权限（兼容所有 Android 版本）
-     */
     private void checkAndRequestStoragePermission() {
         logUtils.d(TAG, "checkAndRequestStoragePermission: Called on Android " + Build.VERSION.RELEASE + " (API " + Build.VERSION.SDK_INT + ")");
         
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            // Android 11+ 需要 MANAGE_EXTERNAL_STORAGE
             if (!android.os.Environment.isExternalStorageManager()) {
-                logUtils.w(TAG, "❌ MANAGE_EXTERNAL_STORAGE not granted on Android " + Build.VERSION.RELEASE + ", showing dialog...");
+                logUtils.w(TAG, "❌ MANAGE_EXTERNAL_STORAGE not granted, showing dialog...");
                 
                 new AlertDialog.Builder(this)
                     .setTitle("需要文件管理权限")
@@ -398,16 +403,14 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
                     .setNegativeButton("取消", null)
                     .show();
             } else {
-                logUtils.d(TAG, "✅ MANAGE_EXTERNAL_STORAGE already granted on Android " + Build.VERSION.RELEASE);
+                logUtils.d(TAG, "✅ MANAGE_EXTERNAL_STORAGE already granted");
             }
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            // Android 10 使用分区存储，不需要特殊权限
             logUtils.d(TAG, "✅ Android 10 uses scoped storage, no special permission needed");
         } else {
-            // Android 9 及以下需要 WRITE_EXTERNAL_STORAGE 运行时权限
             if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
                     != PackageManager.PERMISSION_GRANTED) {
-                logUtils.w(TAG, "❌ WRITE_EXTERNAL_STORAGE not granted on Android " + Build.VERSION.RELEASE + ", requesting...");
+                logUtils.w(TAG, "❌ WRITE_EXTERNAL_STORAGE not granted, requesting...");
                 
                 ActivityCompat.requestPermissions(
                     this,
@@ -415,14 +418,11 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
                     STORAGE_PERMISSION_REQUEST_CODE
                 );
             } else {
-                logUtils.d(TAG, "✅ WRITE_EXTERNAL_STORAGE already granted on Android " + Build.VERSION.RELEASE);
+                logUtils.d(TAG, "✅ WRITE_EXTERNAL_STORAGE already granted");
             }
         }
     }
     
-    /**
-     * 打开系统设置页面，请求 MANAGE_EXTERNAL_STORAGE 权限
-     */
     private void openStoragePermissionSettings() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             Intent intent = new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
@@ -431,9 +431,6 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
         }
     }
 
-    /**
-     * 检查通知权限（Android 13+）
-     */
     private void checkNotificationPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
@@ -450,9 +447,6 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
         }
     }
     
-    /**
-     * 处理权限请求结果
-     */
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
@@ -460,18 +454,18 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
         
         if (requestCode == STORAGE_PERMISSION_REQUEST_CODE) {
             if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                logUtils.i(TAG, "✅ onRequestPermissionsResult: WRITE_EXTERNAL_STORAGE permission granted on Android " + Build.VERSION.RELEASE);
+                logUtils.i(TAG, "✅ WRITE_EXTERNAL_STORAGE permission granted");
                 Toast.makeText(this, "存储权限已授予，日志将写入到 /sdcard/Download/joyman_logs/", Toast.LENGTH_LONG).show();
             } else {
-                logUtils.w(TAG, "❌ onRequestPermissionsResult: WRITE_EXTERNAL_STORAGE permission denied on Android " + Build.VERSION.RELEASE);
+                logUtils.w(TAG, "❌ WRITE_EXTERNAL_STORAGE permission denied");
                 Toast.makeText(this, "存储权限被拒绝，日志将无法写入", Toast.LENGTH_LONG).show();
             }
         } else if (requestCode == NOTIFICATION_PERMISSION_REQUEST_CODE) {
             if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                logUtils.i(TAG, "onRequestPermissionsResult: Notification permission granted");
+                logUtils.i(TAG, "Notification permission granted");
                 Toast.makeText(this, "通知权限已授予，API 服务将显示通知", Toast.LENGTH_SHORT).show();
             } else {
-                logUtils.w(TAG, "onRequestPermissionsResult: Notification permission denied");
+                logUtils.w(TAG, "Notification permission denied");
                 Toast.makeText(this, "通知权限被拒绝，API 服务可能无法正常显示通知", Toast.LENGTH_LONG).show();
             }
         }
@@ -481,18 +475,15 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu_main, menu);
         
-        // 初始化搜索框
         MenuItem searchItem = menu.findItem(R.id.action_search);
         searchView = (SearchView) searchItem.getActionView();
         
         if (searchView != null) {
             searchView.setQueryHint("搜索任务（支持多关键词）");
             
-            // 设置搜索监听器
             searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
                 @Override
                 public boolean onQueryTextSubmit(String query) {
-                    // 提交搜索
                     performSearch(query);
                     searchView.clearFocus();
                     return true;
@@ -500,18 +491,15 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
                 
                 @Override
                 public boolean onQueryTextChange(String newText) {
-                    // 实时搜索（可选，如果不需要实时搜索可以返回 false）
                     if (newText.isEmpty()) {
                         clearSearch();
                     } else if (newText.length() >= 2) {
-                        // 至少 2 个字符才开始搜索
                         performSearch(newText);
                     }
                     return true;
                 }
             });
             
-            // 设置关闭监听器
             searchView.setOnCloseListener(() -> {
                 clearSearch();
                 return false;
@@ -521,9 +509,6 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
         return true;
     }
     
-    /**
-     * 执行搜索
-     */
     private void performSearch(String keywords) {
         if (keywords == null || keywords.trim().isEmpty()) {
             clearSearch();
@@ -533,10 +518,8 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
         isSearching = true;
         logUtils.d(TAG, "performSearch: Searching with keywords: " + keywords);
         
-        // 调用 ViewModel 进行搜索
         taskViewModel.searchTasksByKeywords(keywords).observe(this, tasks -> {
             if (tasks != null) {
-                // 过滤掉已关闭的任务
                 List<Task> filteredTasks = tasks.stream()
                     .filter(task -> task.getStatus() != Task.STATUS_CLOSED)
                     .collect(java.util.stream.Collectors.toList());
@@ -552,9 +535,6 @@ public class MainActivity extends AppCompatActivity implements TaskAdapter.OnTas
         });
     }
     
-    /**
-     * 清除搜索，恢复完整列表
-     */
     private void clearSearch() {
         isSearching = false;
         logUtils.d(TAG, "clearSearch: Clearing search and restoring full list");

--- a/app/src/main/java/com/stupidbeauty/joyman/api/ApiForegroundService.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/api/ApiForegroundService.java
@@ -8,13 +8,10 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.net.Uri;
 import android.os.Build;
-import android.provider.Settings;
-import android.service.notification.StatusBarNotification;
+import android.os.IBinder;
 import android.widget.Toast;
 
-import androidx.appcompat.app.AlertDialog;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
@@ -47,12 +44,8 @@ public class ApiForegroundService extends Service {
         }
         logUtilsInfo(context, "🚀 Starting ApiForegroundService");
         
-        // 检查通知是否被禁用
-        if (!isNotificationsEnabled(context)) {
-            logUtilsInfo(context, "❌ Notifications are DISABLED! Showing settings dialog...");
-            showNotificationSettingsDialog(context);
-            // 即使通知被禁用，也尝试启动服务（但用户可能看不到通知）
-        }
+        // 注意：不再在这里检查通知或显示对话框
+        // 对话框应该在 MainActivity 中显示
         
         Intent intent = new Intent(context, ApiForegroundService.class);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -64,9 +57,9 @@ public class ApiForegroundService extends Service {
     
     /**
      * 检查应用的通知权限是否被用户或系统禁用
+     * 可以在任何 Context 中调用
      */
     public static boolean isNotificationsEnabled(Context context) {
-        // Android 7.0+ 可以使用 areNotificationsEnabled()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             NotificationManagerCompat manager = NotificationManagerCompat.from(context);
             boolean enabled = manager.areNotificationsEnabled();
@@ -84,72 +77,88 @@ public class ApiForegroundService extends Service {
             return enabled;
         }
         
-        // Android 6.0 及以下默认启用通知
         return true;
     }
     
     /**
-     * 显示通知设置对话框，引导用户到系统设置页面
+     * 在 MainActivity 中显示通知设置对话框
+     * 必须在 Activity 环境中调用
      */
-    public static void showNotificationSettingsDialog(Context context) {
+    public static void showNotificationSettingsDialog(MainActivity activity) {
         LogUtils logUtils = LogUtils.getInstance();
         if (logUtils != null) {
-            logUtils.w(TAG, "📢 Showing notification settings dialog...");
+            logUtils.w(TAG, "📢 Showing notification settings dialog in MainActivity...");
         }
         
-        new AlertDialog.Builder(context)
-            .setTitle("⚠️ 通知权限已关闭")
-            .setMessage(
-                "JoyMan 需要通知权限来保持 API 服务在前台运行。\n\n" +
-                "检测到您的设备已关闭 JoyMan 的通知权限，这会导致：\n" +
-                "• ❌ 无法看到 API 服务运行状态\n" +
-                "• ❌ 服务可能被系统自动杀死\n" +
-                "• ❌ 日志功能可能受影响\n\n" +
-                "请点击「去设置」手动开启通知权限：\n" +
-                "1. 点击「允许通知」开关\n" +
-                "2. 确保「JoyMan API 服务」渠道已启用\n" +
-                "3. 将重要性设置为「高」或「紧急」\n\n" +
-                "💡 提示：这是 Android 系统的安全机制，需要用户手动授权。"
-            )
-            .setPositiveButton("⚙️ 去设置", (dialog, which) -> {
-                // 打开应用通知设置页面
-                Intent intent = new Intent();
-                intent.setAction(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
-                intent.putExtra(Settings.EXTRA_APP_PACKAGE, context.getPackageName());
-                intent.putExtra(Settings.EXTRA_CHANNEL_ID, CHANNEL_ID);
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                context.startActivity(intent);
+        if (activity == null || activity.isFinishing()) {
+            if (logUtils != null) {
+                logUtils.e(TAG, "❌ Cannot show dialog: Activity is null or finishing");
+            }
+            return;
+        }
+        
+        try {
+            new androidx.appcompat.app.AlertDialog.Builder(activity)
+                .setTitle("⚠️ 通知权限已关闭")
+                .setMessage(
+                    "JoyMan 需要通知权限来保持 API 服务在前台运行。\n\n" +
+                    "检测到您的设备已关闭 JoyMan 的通知权限，这会导致：\n" +
+                    "• ❌ 无法看到 API 服务运行状态\n" +
+                    "• ❌ 服务可能被系统自动杀死\n" +
+                    "• ❌ 日志功能可能受影响\n\n" +
+                    "请点击「去设置」手动开启通知权限：\n" +
+                    "1. 点击「允许通知」开关\n" +
+                    "2. 确保「JoyMan API 服务」渠道已启用\n" +
+                    "3. 将重要性设置为「高」或「紧急」\n\n" +
+                    "💡 提示：这是 Android 系统的安全机制，需要用户手动授权。"
+                )
+                .setPositiveButton("⚙️ 去设置", (dialog, which) -> {
+                    Intent intent = new Intent();
+                    intent.setAction(android.provider.Settings.ACTION_APP_NOTIFICATION_SETTINGS);
+                    intent.putExtra(android.provider.Settings.EXTRA_APP_PACKAGE, activity.getPackageName());
+                    intent.putExtra(android.provider.Settings.EXTRA_CHANNEL_ID, CHANNEL_ID);
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    activity.startActivity(intent);
+                    
+                    if (logUtils != null) {
+                        logUtils.i(TAG, "✅ Opened notification settings page");
+                    }
+                })
+                .setNegativeButton("❌ 取消", (dialog, which) -> {
+                    if (logUtils != null) {
+                        logUtils.w(TAG, "⚠️ User declined to open notification settings");
+                    }
+                    Toast.makeText(activity, 
+                        "⚠️ 通知未开启，API 服务可能无法正常运行", 
+                        Toast.LENGTH_LONG).show();
+                })
+                .setNeutralButton("❓ 为什么需要通知？", (dialog, which) -> {
+                    new androidx.appcompat.app.AlertDialog.Builder(activity)
+                        .setTitle("为什么需要通知权限？")
+                        .setMessage(
+                            "Android 系统要求前台服务必须显示持久通知，这是为了：\n\n" +
+                            "✅ 透明度：让用户知道有服务在后台运行\n" +
+                            "✅ 可控性：用户可以随时通过通知管理或停止服务\n" +
+                            "✅ 电池优化：系统可以智能管理后台服务的电量消耗\n\n" +
+                            "JoyMan 的 API 服务需要持续运行以提供 REST API 接口，" +
+                            "因此必须显示通知来告知用户服务正在运行。\n\n" +
+                            "🔒 隐私说明：该通知不会收集或泄露任何个人信息。"
+                        )
+                        .setPositiveButton("明白了", null)
+                        .show();
+                })
+                .setCancelable(false)
+                .show();
                 
-                if (logUtils != null) {
-                    logUtils.i(TAG, "✅ Opened notification settings page");
-                }
-            })
-            .setNegativeButton("❌ 取消", (dialog, which) -> {
-                if (logUtils != null) {
-                    logUtils.w(TAG, "⚠️ User declined to open notification settings");
-                }
-                Toast.makeText(context, 
-                    "⚠️ 通知未开启，API 服务可能无法正常运行", 
-                    Toast.LENGTH_LONG).show();
-            })
-            .setNeutralButton("❓ 为什么需要通知？", (dialog, which) -> {
-                // 显示详细说明
-                new AlertDialog.Builder(context)
-                    .setTitle("为什么需要通知权限？")
-                    .setMessage(
-                        "Android 系统要求前台服务必须显示持久通知，这是为了：\n\n" +
-                        "✅ 透明度：让用户知道有服务在后台运行\n" +
-                        "✅ 可控性：用户可以随时通过通知管理或停止服务\n" +
-                        "✅ 电池优化：系统可以智能管理后台服务的电量消耗\n\n" +
-                        "JoyMan 的 API 服务需要持续运行以提供 REST API 接口，" +
-                        "因此必须显示通知来告知用户服务正在运行。\n\n" +
-                        "🔒 隐私说明：该通知不会收集或泄露任何个人信息。"
-                    )
-                    .setPositiveButton("明白了", null)
-                    .show();
-            })
-            .setCancelable(false)
-            .show();
+            if (logUtils != null) {
+                logUtils.i(TAG, "✅ Dialog shown successfully");
+            }
+        } catch (Exception e) {
+            if (logUtils != null) {
+                logUtils.e(TAG, "❌ Failed to show dialog", e);
+            }
+            Toast.makeText(activity, "⚠️ 请手动到设置中开启通知权限", Toast.LENGTH_LONG).show();
+        }
     }
     
     public static void stop(Context context) {
@@ -176,12 +185,6 @@ public class ApiForegroundService extends Service {
         logUtils = LogUtils.getInstance();
         logUtils.i(TAG, "✅ onCreate: API Foreground Service on Android " + Build.VERSION.RELEASE);
         
-        // 再次检查通知状态
-        if (!isNotificationsEnabled(this)) {
-            logUtils.e(TAG, "❌ Notifications still disabled in onCreate!");
-            Toast.makeText(this, "⚠️ 通知权限已关闭，请在设置中开启", Toast.LENGTH_LONG).show();
-        }
-        
         if (!checkStoragePermission()) {
             logUtils.w(TAG, "❌ Storage permission not granted");
             Intent mainIntent = new Intent(this, MainActivity.class);
@@ -204,11 +207,11 @@ public class ApiForegroundService extends Service {
         isRunning = true;
         logUtils.i(TAG, "▶️ Starting API foreground service");
         
-        // 最终检查：如果通知仍被禁用，显示 Toast 警告
+        // 检查但不显示对话框（对话框已在 MainActivity 中显示）
         if (!isNotificationsEnabled(this)) {
-            logUtils.e(TAG, "⚠️️⚠️ CRITICAL: Notifications are DISABLED! Service may be killed by system.");
+            logUtils.e(TAG, "⚠️️ CRITICAL: Notifications are DISABLED!");
             Toast.makeText(this, 
-                "⚠️ 通知权限未开启！\n请下拉通知栏查看设置提示，或到设置中手动开启", 
+                "⚠️ 通知权限未开启！请下拉到设置中手动开启", 
                 Toast.LENGTH_LONG).show();
         }
         
@@ -220,11 +223,6 @@ public class ApiForegroundService extends Service {
         logUtils.i(TAG, "🔔 Calling startForeground");
         startForeground(NOTIFICATION_ID, notification);
         logUtils.i(TAG, "✅ startForeground() called - service is FOREGROUND");
-        
-        // 如果通知被禁用，1 秒后再次提醒
-        if (!isNotificationsEnabled(this)) {
-            postDelayedNotificationReminder();
-        }
         
         try {
             apiService = new JoyManApiService(this, DEFAULT_PORT);
@@ -239,44 +237,6 @@ public class ApiForegroundService extends Service {
         }
         
         return START_STICKY;
-    }
-    
-    /**
-     * 延迟显示通知提醒
-     */
-    private void postDelayedNotificationReminder() {
-        new android.os.Handler(getMainLooper()).postDelayed(() -> {
-            if (!isNotificationsEnabled(ApiForegroundService.this)) {
-                logUtils.e(TAG, "⚠️ Reminder: Notifications still disabled!");
-                
-                // 尝试发送一个高优先级的测试通知（可能会被系统阻止，但值得一试）
-                try {
-                    NotificationManager manager = getSystemService(NotificationManager.class);
-                    if (manager != null) {
-                        NotificationCompat.Builder reminderBuilder = new NotificationCompat.Builder(this, CHANNEL_ID)
-                            .setContentTitle("⚠️ 请开启通知权限")
-                            .setContentText("点击此处进入设置页面开启 JoyMan 的通知权限")
-                            .setSmallIcon(android.R.drawable.ic_dialog_alert)
-                            .setPriority(NotificationCompat.PRIORITY_MAX)
-                            .setCategory(NotificationCompat.CATEGORY_SERVICE)
-                            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-                            .setAutoCancel(true)
-                            .setContentIntent(PendingIntent.getActivity(
-                                this, 0,
-                                new Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
-                                    .putExtra(Settings.EXTRA_APP_PACKAGE, getPackageName())
-                                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
-                            ));
-                        
-                        manager.notify(8888, reminderBuilder.build());
-                        logUtils.i(TAG, "📢 Sent reminder notification (ID: 8888)");
-                    }
-                } catch (Exception e) {
-                    logUtils.e(TAG, "❌ Failed to send reminder notification", e);
-                }
-            }
-        }, 1000); // 1 秒后检查
     }
     
     @Override
@@ -319,9 +279,8 @@ public class ApiForegroundService extends Service {
                     logUtils.i(TAG, "   - Lockscreen Visibility: " + channel.getLockscreenVisibility());
                     logUtils.i(TAG, "   - Show Badge: " + channel.canShowBadge());
                     
-                    // 检查渠道本身是否被用户禁用
                     if (channel.getImportance() == NotificationManager.IMPORTANCE_NONE) {
-                        logUtils.e(TAG, "❌ CRITICAL: Channel importance is NONE! User may have disabled this channel.");
+                        logUtils.e(TAG, "❌ CRITICAL: Channel importance is NONE!");
                     }
                     
                     postTestNotification(manager);
@@ -393,7 +352,6 @@ public class ApiForegroundService extends Service {
                         logUtils.i(TAG, "✅ SUCCESS: Channel importance correctly set to HIGH (4)");
                     } else {
                         logUtils.e(TAG, "❌ FAILED: Expected importance 4 but got " + createdChannel.getImportance());
-                        logUtils.e(TAG, "💡 This may be due to ROM-specific restrictions");
                     }
                 }
             } else {


### PR DESCRIPTION
## 问题描述
Android 9 (努比亚 JOS) 上通知栏通知不显示，且尝试显示设置对话框时崩溃。

**根本原因**：
1. 用户在系统设置中关闭了 JoyMan 的应用级通知权限
2. 代码尝试在 `Application.onCreate()` 中显示 AlertDialog，导致 `Theme.AppCompat` 错误
3. API 服务初始化失败，前台服务无法启动

## 修复内容

### 1. ApiForegroundService.java
- ✅ 移除 `start()` 方法中的对话框调用（避免在 Application 环境中显示 UI）
- ✅ 修改 `showNotificationSettingsDialog()` 接受 `MainActivity` 参数
- ✅ 添加 Activity 状态检查（`isFinishing()`）
- ✅ 简化服务启动逻辑，只负责启动服务，不负责显示 UI

### 2. MainActivity.java
- ✅ 导入 `ApiForegroundService`
- ✅ 添加 `checkAppNotificationsEnabled()` 方法
- ✅ 在 `onCreate()` 中延迟 500ms 检查通知状态
- ✅ 如果禁用则显示对话框（使用 Activity 上下文）
- ✅ 添加详细日志记录检查过程

## 技术说明

**执行流程**：
```
MainActivity.onCreate()
  → 延迟 500ms（确保 Activity 完全初始化）
    → checkAppNotificationsEnabled()
      → ApiForegroundService.isNotificationsEnabled()
        → 如果禁用：showNotificationSettingsDialog(MainActivity)
          → 显示 AlertDialog ✓（不会崩溃）
            → 用户点击"去设置"
              → 跳转到系统通知设置页面
                → 用户开启通知
                  → 返回应用，通知正常显示
```

**关键修复点**：
- ❌ **之前**: 在 `Application` 环境中显示 Dialog → 崩溃
- ✅ **现在**: 在 `MainActivity` 环境中显示 Dialog → 正常工作

## 测试步骤
1. 安装新版本 APK
2. 确保通知权限已关闭（设置 → 应用 → JoyMan → 通知 → 关闭）
3. 打开应用
4. 等待 1-2 秒，应该看到"⚠️ 通知权限已关闭"对话框
5. 点击"去设置"，自动跳转到通知设置页面
6. 开启"允许通知"开关
7. 返回应用，应该能看到：
   - Toast: "JoyMan API 服务已启动"
   - 通知栏: "JoyMan API 服务" 通知
   - 通知栏: "JoyMan 测试通知" (ID: 9999)

## 日志验证
成功时日志应显示：
```
✅ App notifications are DISABLED! Showing dialog...
📢 Showing notification settings dialog in MainActivity...
✅ Dialog shown successfully
✅ Opened notification settings page
```

失败时日志应显示：
```
❌ Failed to show dialog: Activity is null or finishing
```

## 关联问题
- Android 9 通知渠道重要性缓存问题（已通过更改渠道 ID 解决）
- 努比亚 JOS ROM 的通知限制（通过引导用户手动开启解决）