### PR TITLE
fix: use ACTION_APPLICATION_DETAILS_SETTINGS to show master notification toggle

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/api/ApiForegroundService.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/api/ApiForegroundService.java
@@ -8,8 +8,9 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Build;
-import android.os.IBinder;
+import android.provider.Settings;
 import android.widget.Toast;
 
 import androidx.core.app.ActivityCompat;
@@ -70,7 +71,7 @@ public class ApiForegroundService extends Service {
                 
                 if (!enabled) {
                     logUtils.e(TAG, "❌ NOTIFICATIONS ARE DISABLED!");
-                    logUtils.e(TAG, "💡 User must manually enable in Settings → Apps → JoyMan → Notifications");
+                    logUtils.e(TAG, "💡 User must manually enable in Settings → Apps → JoyMan → Notifications → 允许通知");
                 }
             }
             
@@ -83,6 +84,15 @@ public class ApiForegroundService extends Service {
     /**
      * 在 MainActivity 中显示通知设置对话框
      * 必须在 Activity 环境中调用
+     * 
+     * 重要：使用 ACTION_APPLICATION_DETAILS_SETTINGS 而不是 ACTION_APP_NOTIFICATION_SETTINGS
+     * 原因：
+     * 1. ACTION_APP_NOTIFICATION_SETTINGS 直接跳转到渠道级设置，总开关可能被隐藏
+     * 2. ACTION_APPLICATION_DETAILS_SETTINGS 打开完整的应用信息页面，用户可以：
+     *    - 看到"通知"这一行（显示"关闭"状态）
+     *    - 点击进入后看到"允许通知"总开关
+     *    - 开启总开关后才能操作具体的通知渠道
+     * 3. 这对国产 ROM（如 JOS、MIUI、EMUI）尤其重要
      */
     public static void showNotificationSettingsDialog(MainActivity activity) {
         LogUtils logUtils = LogUtils.getInstance();
@@ -106,22 +116,23 @@ public class ApiForegroundService extends Service {
                     "• ❌ 无法看到 API 服务运行状态\n" +
                     "• ❌ 服务可能被系统自动杀死\n" +
                     "• ❌ 日志功能可能受影响\n\n" +
-                    "请点击「去设置」手动开启通知权限：\n" +
-                    "1. 点击「允许通知」开关\n" +
-                    "2. 确保「JoyMan API 服务」渠道已启用\n" +
-                    "3. 将重要性设置为「高」或「紧急」\n\n" +
+                    "请点击「去设置」，然后按以下步骤操作：\n" +
+                    "1. 点击「通知」这一行（显示「关闭」状态）\n" +
+                    "2. 开启「允许通知」总开关\n" +
+                    "3. 确保「JoyMan API 服务」渠道已启用\n\n" +
                     "💡 提示：这是 Android 系统的安全机制，需要用户手动授权。"
                 )
                 .setPositiveButton("⚙️ 去设置", (dialog, which) -> {
+                    // 打开应用信息页面（而不是直接跳到通知详情页）
                     Intent intent = new Intent();
-                    intent.setAction(android.provider.Settings.ACTION_APP_NOTIFICATION_SETTINGS);
-                    intent.putExtra(android.provider.Settings.EXTRA_APP_PACKAGE, activity.getPackageName());
-                    intent.putExtra(android.provider.Settings.EXTRA_CHANNEL_ID, CHANNEL_ID);
+                    intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                    intent.setData(Uri.fromParts("package", activity.getPackageName(), null));
                     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     activity.startActivity(intent);
                     
                     if (logUtils != null) {
-                        logUtils.i(TAG, "✅ Opened notification settings page");
+                        logUtils.i(TAG, "✅ Opened app info page (ACTION_APPLICATION_DETAILS_SETTINGS)");
+                        logUtils.i(TAG, "💡 User should click: 通知 → 允许通知");
                     }
                 })
                 .setNegativeButton("❌ 取消", (dialog, which) -> {
@@ -133,6 +144,7 @@ public class ApiForegroundService extends Service {
                         Toast.LENGTH_LONG).show();
                 })
                 .setNeutralButton("❓ 为什么需要通知？", (dialog, which) -> {
+                    // 显示详细说明
                     new androidx.appcompat.app.AlertDialog.Builder(activity)
                         .setTitle("为什么需要通知权限？")
                         .setMessage(
@@ -185,6 +197,12 @@ public class ApiForegroundService extends Service {
         logUtils = LogUtils.getInstance();
         logUtils.i(TAG, "✅ onCreate: API Foreground Service on Android " + Build.VERSION.RELEASE);
         
+        // 再次检查通知状态
+        if (!isNotificationsEnabled(this)) {
+            logUtils.e(TAG, "❌ Notifications still disabled in onCreate!");
+            Toast.makeText(this, "⚠️ 通知权限已关闭，请在设置中开启", Toast.LENGTH_LONG).show();
+        }
+        
         if (!checkStoragePermission()) {
             logUtils.w(TAG, "❌ Storage permission not granted");
             Intent mainIntent = new Intent(this, MainActivity.class);
@@ -207,9 +225,9 @@ public class ApiForegroundService extends Service {
         isRunning = true;
         logUtils.i(TAG, "▶️ Starting API foreground service");
         
-        // 检查但不显示对话框（对话框已在 MainActivity 中显示）
+        // 最终检查：如果通知仍被禁用，显示 Toast 警告
         if (!isNotificationsEnabled(this)) {
-            logUtils.e(TAG, "⚠️️ CRITICAL: Notifications are DISABLED!");
+            logUtils.e(TAG, "⚠️️ CRITICAL: Notifications are DISABLED! Service may be killed by system.");
             Toast.makeText(this, 
                 "⚠️ 通知权限未开启！请下拉到设置中手动开启", 
                 Toast.LENGTH_LONG).show();
@@ -352,6 +370,7 @@ public class ApiForegroundService extends Service {
                         logUtils.i(TAG, "✅ SUCCESS: Channel importance correctly set to HIGH (4)");
                     } else {
                         logUtils.e(TAG, "❌ FAILED: Expected importance 4 but got " + createdChannel.getImportance());
+                        logUtils.e(TAG, "💡 This may be due to ROM-specific restrictions");
                     }
                 }
             } else {


### PR DESCRIPTION
## 问题描述
用户反馈：点击"去设置"后虽然能打开通知设置页面，但"JoyMan API 服务"渠道的开关是灰色的，无法点击开启。

**根本原因**：
- 代码使用了 `ACTION_APP_NOTIFICATION_SETTINGS` 直接跳转到**渠道级**通知设置页面
- 在国产 ROM（如 JOS、MIUI、EMUI）上，当**应用级总开关**关闭时，渠道级开关会被禁用（变灰）
- 用户看不到"允许通知"总开关在哪里，无法开启

**正确流程**：
```
❌ 之前：应用 → 渠道详情页 → 开关灰色 ✗ 无法操作
✅ 现在：应用信息页 → 点击"通知" → 看到"允许通知"总开关 → 开启 ✓
```

## 修复内容

### ApiForegroundService.java
1. **更改 Intent Action**：
   - 从 `ACTION_APP_NOTIFICATION_SETTINGS` 改为 `ACTION_APPLICATION_DETAILS_SETTINGS`
   - 打开完整的应用信息页面，而不是直接跳到渠道详情页

2. **更新对话框提示文字**：
   ```
   请点击「去设置」，然后按以下步骤操作：
   1. 点击「通知」这一行（显示「关闭」状态）
   2. 开启「允许通知」总开关
   3. 确保「JoyMan API 服务」渠道已启用
   ```

3. **添加详细注释**：
   - 解释为什么必须使用 `ACTION_APPLICATION_DETAILS_SETTINGS`
   - 说明国产 ROM 的通知权限层级结构
   - 强调必须先开启应用级总开关

## 技术说明

### Android 通知权限层级
```
应用级通知权限 (总开关)
├─ 渠道 1: JoyMan API 服务
├─ 渠道 2: 其他通知
└─ ...
```

- **应用级总开关**：控制整个应用是否能发送通知
- **渠道级开关**：控制具体类型的通知是否显示
- **规则**：总开关关闭时，所有渠道开关都会被禁用

### Intent Action 对比

| Action | 跳转位置 | 优点 | 缺点 |
|--------|---------|------|------|
| `ACTION_APP_NOTIFICATION_SETTINGS` | 渠道详情页 | 直接 | 看不到总开关（国产 ROM） |
| `ACTION_APPLICATION_DETAILS_SETTINGS` | 应用信息页 | 能看到所有设置 | 需要多点击一次 |

**选择**：为了兼容国产 ROM，选择 `ACTION_APPLICATION_DETAILS_SETTINGS`

## 测试步骤
1. 安装新版本 APK
2. 确保通知权限已关闭
3. 打开应用，等待对话框出现
4. 点击"去设置"
5. **应该看到应用信息页面**（包含"通知"、"权限"、"存储"等选项）
6. 点击"通知"这一行
7. 看到"允许通知"总开关
8. 开启总开关
9. 返回应用，通知应该正常显示

## 预期效果
- ✅ 用户能清楚看到"通知"这一行显示"关闭"状态
- ✅ 点击进入后能看到"允许通知"总开关
- ✅ 总开关不是灰色的，可以正常点击
- ✅ 开启总开关后，渠道级开关也能操作了
- ✅ API 服务正常启动，通知栏显示"JoyMan API 服务"

## 关联问题
- Android 9 通知渠道重要性缓存问题（已通过更改渠道 ID 解决）
- 努比亚 JOS ROM 的通知限制（通过引导用户手动开启总开关解决）