### PR TITLE
fix: 修复 Android 9 前台服务兼容性问题

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,6 @@
     
     <!-- 前台服务权限 -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     
     <!-- 通知权限（Android 13+） -->
@@ -70,11 +69,8 @@
             android:name=".api.ApiForegroundService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="specialUse"
+            android:foregroundServiceType="dataSync"
             android:process=":api_service">
-            <property
-                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
-                android:value="rest_api_server" />
         </service>
         
     </application>


### PR DESCRIPTION
## 问题描述
修复 JoyMan 在 Android 9 设备上的前台服务兼容性问题。

当前配置使用了 Android 14 (API 34) 才引入的 `FOREGROUND_SERVICE_TYPE_SPECIAL_USE` 类型，导致 Android 9 设备无法正确激活前台服务，后台网络访问被系统限制阻断。

## 修改内容
1. **移除** `FOREGROUND_SERVICE_SPECIAL_USE` 权限（Android 14+ 专用）
2. **修改** 前台服务类型从 `specialUse` 改为 `dataSync`（兼容 Android 9+）
3. **移除** Android 14 专用的 `<property>` 标签
4. **保留** `FOREGROUND_SERVICE_DATA_SYNC` 权限

## 影响范围
- ✅ 修复：Android 9-13 设备的前台服务功能
- ✅ 兼容：Android 14+ 设备（`dataSync` 类型在所有版本均受支持）
- ⚠️ 注意：`specialUse` 类型仅适用于特定系统级应用，普通应用应使用标准类型

## 测试建议
1. 在 Android 9 设备（如努比亚 NX616J）上验证：
   - 前台服务通知正常显示
   - 应用在后台时网络访问正常
   - API 服务持续运行不中断
2. 在 Android 14+ 设备上回归测试

## 相关链接
- Redmine 任务：#784932532567
- 问题报告：JoyMan 在努比亚手机上后台网络被限制

---

**紧急程度**：高 - 影响所有 Android 9-13 用户的核心功能