### PR TITLE
feat: 添加电池优化自动检测和引导功能

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/MainActivity.kt
+++ b/app/src/main/java/com/stupidbeauty/joyman/MainActivity.kt
@@ -1,0 +1,44 @@
+package com.stupidbeauty.joyman
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.appcompat.app.AppCompatActivity
+import com.stupidbeauty.joyman.util.BatteryOptimizationHelper
+
+/**
+ * 主 Activity
+ * 
+ * 应用启动入口，负责显示任务列表和初始化核心功能。
+ */
+class MainActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        // 延迟检测电池优化状态，避免干扰 UI 初始化
+        Handler(Looper.getMainLooper()).postDelayed({
+            checkBatteryOptimization()
+        }, 500L)
+    }
+
+    /**
+     * 检查电池优化状态并引导用户配置
+     */
+    private fun checkBatteryOptimization() {
+        // 如果已忽略电池优化，则不显示提示
+        if (BatteryOptimizationHelper.isIgnoringBatteryOptimizations(this)) {
+            return
+        }
+
+        // 显示引导对话框
+        BatteryOptimizationHelper.showBatteryOptimizationGuideDialog(this)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // 用户从设置页面返回后，可以再次检查状态（可选）
+        // 如果需要自动刷新 UI，可在此处添加逻辑
+    }
+}

--- a/app/src/main/java/com/stupidbeauty/joyman/util/BatteryOptimizationHelper.kt
+++ b/app/src/main/java/com/stupidbeauty/joyman/util/BatteryOptimizationHelper.kt
@@ -1,0 +1,111 @@
+package com.stupidbeauty.joyman.util
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
+import android.provider.Settings
+import androidx.appcompat.app.AlertDialog
+import com.stupidbeauty.joyman.R
+
+/**
+ * 电池优化辅助工具
+ * 
+ * 用于检测和应用是否被系统电池优化限制，并引导用户手动关闭优化。
+ * 
+ * 问题背景：
+ * 国产 Android ROM（如努比亚、小米、华为等）默认对后台应用进行严格的电池优化，
+ * 导致即使配置了前台服务，应用在后台时网络访问仍可能被系统阻断。
+ * 
+ * 解决方案：
+ * 1. 检测应用是否被电池优化限制
+ * 2. 引导用户跳转到系统设置页面
+ * 3. 用户手动将应用设置为"不管控"或"无限制"模式
+ */
+object BatteryOptimizationHelper {
+
+    /**
+     * 检查应用是否忽略了电池优化
+     * 
+     * @param context 上下文
+     * @return true 如果已忽略电池优化（即未被限制），false 如果仍受限制
+     */
+    fun isIgnoringBatteryOptimizations(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+            powerManager.isIgnoringBatteryOptimizations(context.packageName)
+        } else {
+            // Android 6.0 以下没有电池优化机制，视为已忽略
+            true
+        }
+    }
+
+    /**
+     * 获取跳转到电池优化设置页面的 Intent
+     * 
+     * @param context 上下文
+     * @return 可启动的 Intent，用于跳转到系统设置页面
+     */
+    fun getBatteryOptimizationSettingsIntent(context: Context): Intent {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                data = Uri.parse("package:${context.packageName}")
+            }
+        } else {
+            // Android 6.0 以下跳转到应用详情页面
+            Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = Uri.parse("package:${context.packageName}")
+            }
+        }
+    }
+
+    /**
+     * 显示电池优化引导对话框
+     * 
+     * @param context Activity 上下文
+     * @param onDismiss 对话框关闭后的回调
+     */
+    fun showBatteryOptimizationGuideDialog(
+        context: androidx.appcompat.app.AppCompatActivity,
+        onDismiss: (() -> Unit)? = null
+    ) {
+        if (!isIgnoringBatteryOptimizations(context)) {
+            AlertDialog.Builder(context)
+                .setTitle("电池优化限制检测")
+                .setMessage(
+                    "检测到系统对 JoyMan 启用了电池优化，这可能导致后台网络访问被限制。\n\n" +
+                    "请点击\"去设置\"，然后将电池策略设置为\"不管控\"或\"无限制\"，\n" +
+                    "以确保 API 服务能够持续运行。"
+                )
+                .setPositiveButton("去设置") { _, _ ->
+                    val intent = getBatteryOptimizationSettingsIntent(context)
+                    context.startActivity(intent)
+                }
+                .setNegativeButton("稍后提醒") { dialog, _ ->
+                    dialog.dismiss()
+                    onDismiss?.invoke()
+                }
+                .setCancelable(false)
+                .show()
+        } else {
+            onDismiss?.invoke()
+        }
+    }
+
+    /**
+     * 检查并引导用户关闭电池优化
+     * 
+     * @param context Activity 上下文
+     * @return true 如果已忽略电池优化或用户已完成设置，false 如果仍需用户操作
+     */
+    fun checkAndGuide(context: androidx.appcompat.app.AppCompatActivity): Boolean {
+        val isIgnored = isIgnoringBatteryOptimizations(context)
+        
+        if (!isIgnored) {
+            showBatteryOptimizationGuideDialog(context)
+        }
+        
+        return isIgnored
+    }
+}


### PR DESCRIPTION
## 问题描述
JoyMan 在努比亚手机等国产 ROM 上，即使配置了前台服务，后台网络访问仍可能被系统电池优化策略阻断。用户需要手动将应用设置为"不管控"模式才能正常工作，但该操作入口隐蔽，很多用户不知道需要配置。

## 解决方案
本 PR 添加了电池优化自动检测和引导功能：

### 新增文件
1. **`BatteryOptimizationHelper.kt`** - 电池优化辅助工具类
   - `isIgnoringBatteryOptimizations()` - 检测是否已忽略电池优化
   - `getBatteryOptimizationSettingsIntent()` - 获取跳转系统设置的 Intent
   - `showBatteryOptimizationGuideDialog()` - 显示引导对话框
   - `checkAndGuide()` - 一键检测并引导

2. **修改 `MainActivity.kt`**
   - 在 `onCreate()` 中延迟调用电池优化检测
   - 如果检测到限制，自动弹窗引导用户到系统设置页面

### 用户体验
- ✅ **自动检测**：应用启动时自动检查电池优化状态
- ✅ **智能提示**：仅在需要时显示提示，避免打扰已配置的用户
- ✅ **一键跳转**：点击"去设置"直接跳转到 JoyMan 的系统设置页面
- ✅ **友好说明**：对话框中清晰说明为什么需要此配置

### 测试建议
1. 在未配置电池优化的设备上安装新版本
2. 启动应用，确认弹出引导对话框
3. 点击"去设置"，确认跳转到正确的系统页面
4. 将电池策略改为"不管控"后返回应用
5. 重启应用，确认不再显示提示

## 影响范围
- ✅ 所有 Android 6.0+ 设备（电池优化机制引入版本）
- ✅ 特别受益：努比亚、小米、华为、OPPO、vivo 等国产 ROM 用户
- ⚠️ 无负面影响：已配置的用户不会看到任何提示

## 相关链接
- 父任务：#784932532567
- 子任务：#785053673506

---

**优先级**: 高 - 这是解决后台网络限制问题的关键用户体验改进