### PR TITLE
[Fix] 修复 Relation 实体类 - 添加外键约束定义

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/data/database/entity/Relation.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/data/database/entity/Relation.java
@@ -4,6 +4,8 @@ import androidx.room.Entity;
 import androidx.room.PrimaryKey;
 import androidx.room.ColumnInfo;
 import androidx.room.Index;
+import androidx.room.ForeignKey;
+
 
 
 /**
@@ -21,6 +23,22 @@ import androidx.room.Index;
     indices = {
         @Index(value = {"issue_id"}),
         @Index(value = {"related_issue_id"})
+    },
+    foreignKeys = {
+        @ForeignKey(
+            entity = Task.class,
+            parentColumns = {"id"},
+            childColumns = {"issue_id"},
+            onDelete = ForeignKey.CASCADE,
+            onUpdate = ForeignKey.NO_ACTION
+        ),
+        @ForeignKey(
+            entity = Task.class,
+            parentColumns = {"id"},
+            childColumns = {"related_issue_id"},
+            onDelete = ForeignKey.CASCADE,
+            onUpdate = ForeignKey.NO_ACTION
+        )
     }
 )
 public class Relation {


### PR DESCRIPTION
## 问题描述
Room 启动时检测到 relations 表结构与实体类定义不一致：
- 数据库表包含外键约束 FOREIGN KEY(issue_id) REFERENCES tasks(id)
- 但 Relation.java 实体类未定义外键约束

## 修复内容
在 @Entity 注解中添加 foreignKeys 属性，定义与数据库一致的外键约束：
- issue_id → tasks.id (ON DELETE CASCADE)
- related_issue_id → tasks.id (ON DELETE CASCADE)

## 技术细节
- 使用 @ForeignKey 注解定义外键
- onDelete = ForeignKey.CASCADE 表示删除任务时自动删除相关关系
- onUpdate = ForeignKey.NO_ACTION 表示更新任务 ID 时不级联更新

## 关联任务
- #791551456664 - [Feature] 支持 /issues/{id}/relations.json 路径