### PR TITLE
[Fix] 修复 Relation 实体类 - 调整 @ForeignKey 注解顺序以匹配数据库

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/data/database/entity/Relation.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/data/database/entity/Relation.java
@@ -28,14 +28,14 @@ import androidx.room.ForeignKey;
         @ForeignKey(
             entity = Task.class,
             parentColumns = {"id"},
-            childColumns = {"issue_id"},
+            childColumns = {"related_issue_id"},
             onDelete = ForeignKey.CASCADE,
             onUpdate = ForeignKey.NO_ACTION
         ),
         @ForeignKey(
             entity = Task.class,
             parentColumns = {"id"},
-            childColumns = {"related_issue_id"},
+            childColumns = {"issue_id"},
             onDelete = ForeignKey.CASCADE,
             onUpdate = ForeignKey.NO_ACTION
         )


### PR DESCRIPTION
## 问题描述
Room 启动时检测到 relations 表结构与实体类定义不一致：
- Room 期望外键顺序: issue_id, related_issue_id
- 数据库实际外键顺序: related_issue_id, issue_id

## 修复内容
调整 Relation.java 中 @Entity 注解的 foreignKeys 属性顺序，使其与数据库中实际的外键约束顺序一致：
1. 先定义 related_issue_id 的外键约束
2. 再定义 issue_id 的外键约束

## 技术细节
- SQLite 重建表时，外键约束的顺序由数据库引擎决定
- 实体类中的 @ForeignKey 注解顺序必须与数据库实际顺序一致
- 否则 Room 会认为 schema 不匹配并抛出异常

## 关联任务
- #791551456664 - [Feature] 支持 /issues/{id}/relations.json 路径