### PR TITLE
[Fix] 修复 Relation 实体类 - 添加 nullable=true 以匹配数据库 schema

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/data/database/entity/Relation.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/data/database/entity/Relation.java
@@ -77,7 +77,7 @@ public class Relation {
      * - "blocks": 主任务阻塞关联任务
      * - "blocked_by": 主任务被关联任务阻塞
      */
-    @ColumnInfo(name = "type")
+    @ColumnInfo(name = "type", nullable = true)
     private String type;
     
     /**


### PR DESCRIPTION
## 问题描述
Room 启动时检测到 relations 表结构与实体类定义不一致：
- Room 期望 type 字段: notNull=false (允许 NULL)
- 数据库实际 type 字段: notNull=true (不允许 NULL)

## 修复内容
在 @ColumnInfo 注解中添加 nullable=true 属性，使 type 字段允许为 NULL，与数据库迁移脚本保持一致。

## 技术细节
- Room 默认将 Java String 类型映射为 TEXT NOT NULL
- 但数据库迁移脚本中 type 字段定义为 TEXT（允许 NULL）
- 需要显式指定 nullable=true 来匹配数据库 schema

## 关联任务
- #791551456664 - [Feature] 支持 /issues/{id}/relations.json 路径