### PR TITLE
[Fix] 修复 ISSUE_RELATIONS_PATTERN 匹配逻辑 - 复用 Matcher 对象

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/api/JoyManApiService.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/api/JoyManApiService.java
@@ -352,34 +352,45 @@ public class JoyManApiService extends NanoHTTPD
             else if (ISSUE_RELATIONS_PATTERN.matcher(uri).matches())
             {
                 // Relations 端点路由
-                long issueId = Long.parseLong(ISSUE_RELATIONS_PATTERN.matcher(uri).group(1));
-                
-                if ("GET".equals(method))
+                // 🔧 修复：复用 Matcher 对象，避免 IllegalStateException
+                Matcher relationsMatcher = ISSUE_RELATIONS_PATTERN.matcher(uri);
+                if (relationsMatcher.matches())
                 {
-                    return handleIssueRelations(session, issueId);
-                }
-                else if ("POST".equals(method))
-                {
-                    return createRelation(session, issueId);
-                }
-                else if ("DELETE".equals(method))
-                {
-                    // 检查是否是删除特定关系 /issues/{id}/relations/{relation_id}.json
-                    Pattern relationDetailPattern = Pattern.compile("^issues\\/(\\d+)\\/relations\\/(\\d+)\\.json$");
-                    Matcher detailMatcher = relationDetailPattern.matcher(uri);
-                    if (detailMatcher.matches())
+                    logUtils.d(TAG, "serve: ISSUE_RELATIONS_PATTERN matched, group(1)=" + relationsMatcher.group(1));
+                    long issueId = Long.parseLong(relationsMatcher.group(1));
+                    
+                    if ("GET".equals(method))
                     {
-                        long relationId = Long.parseLong(detailMatcher.group(2));
-                        return handleIssueRelationDetail(session, issueId, relationId);
+                        return handleIssueRelations(session, issueId);
+                    }
+                    else if ("POST".equals(method))
+                    {
+                        return createRelation(session, issueId);
+                    }
+                    else if ("DELETE".equals(method))
+                    {
+                        // 检查是否是删除特定关系 /issues/{id}/relations/{relation_id}.json
+                        Pattern relationDetailPattern = Pattern.compile("^issues\\/(\\d+)\\/relations\\/(\\d+)\\.json$");
+                        Matcher detailMatcher = relationDetailPattern.matcher(uri);
+                        if (detailMatcher.matches())
+                        {
+                            long relationId = Long.parseLong(detailMatcher.group(2));
+                            return handleIssueRelationDetail(session, issueId, relationId);
+                        }
+                        else
+                        {
+                            return createCorsResponse(Response.Status.BAD_REQUEST, "application/json", "{\"error\":\"Invalid relation delete format\"}");
+                        }
                     }
                     else
                     {
-                        return createCorsResponse(Response.Status.BAD_REQUEST, "application/json", "{\"error\":\"Invalid relation delete format\"}");
+                        return createCorsResponse(Response.Status.METHOD_NOT_ALLOWED, "application/json", "{\"error\":\"Method not allowed\"}");
                     }
                 }
                 else
                 {
-                    return createCorsResponse(Response.Status.METHOD_NOT_ALLOWED, "application/json", "{\"error\":\"Method not allowed\"}");
+                    logUtils.w(TAG, "serve: ISSUE_RELATIONS_PATTERN matched but group extraction failed");
+                    return createCorsResponse(Response.Status.INTERNAL_ERROR, "application/json", "{\"error\":\"Internal server error: Regex match failed\"}");
                 }
             }
             else if (uri.startsWith("issues/") && uri.endsWith(".json"))


### PR DESCRIPTION
## 问题描述
访问 `/issues/{id}/relations.json` 时返回 500 错误：
`java.lang.IllegalStateException: No successful match so far`

## 根本原因
每次调用 `matcher()` 方法都会创建一个新的 Matcher 对象。
原代码中：
1. `ISSUE_RELATIONS_PATTERN.matcher(uri).matches()` - 创建 Matcher A，匹配成功
2. `ISSUE_RELATIONS_PATTERN.matcher(uri).group(1)` - 创建 Matcher B，没有执行 matches()，所以 group(1) 抛出异常

## 修复内容
修改路由逻辑，先获取 Matcher 对象，然后复用它进行匹配和分组提取。

## 技术细节
- 使用 `Matcher relationsMatcher = ISSUE_RELATIONS_PATTERN.matcher(uri)` 创建一次 Matcher
- 使用 `relationsMatcher.matches()` 进行匹配
- 使用 `relationsMatcher.group(1)` 提取分组（此时 matcher 已经处于匹配成功状态）
- 添加调试日志验证修复效果

## 关联任务
- #791551456664 - [Feature] 支持 /issues/{id}/relations.json 路径以管理任务阻塞关系