### PR TITLE
[Fix] 修复 Relations 端点路由逻辑 - 使用 Method 枚举比较

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/api/JoyManApiService.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/api/JoyManApiService.java
@@ -359,15 +359,16 @@ public class JoyManApiService extends NanoHTTPD
                     logUtils.d(TAG, "serve: ISSUE_RELATIONS_PATTERN matched, group(1)=" + relationsMatcher.group(1));
                     long issueId = Long.parseLong(relationsMatcher.group(1));
                     
-                    if ("GET".equals(method))
+                    // 🔧 修复：使用 Method 枚举比较，而不是字符串比较
+                    if (Method.GET.equals(method))
                     {
                         return handleIssueRelations(session, issueId);
                     }
-                    else if ("POST".equals(method))
+                    else if (Method.POST.equals(method))
                     {
                         return createRelation(session, issueId);
                     }
-                    else if ("DELETE".equals(method))
+                    else if (Method.DELETE.equals(method))
                     {
                         // 检查是否是删除特定关系 /issues/{id}/relations/{relation_id}.json
                         Pattern relationDetailPattern = Pattern.compile("^issues\\/(\\d+)\\/relations\\/(\\d+)\\.json$");


### PR DESCRIPTION
## 问题描述
访问 `/issues/{id}/relations.json` 时返回 405 Method Not Allowed 错误。

## 根本原因
`session.getMethod()` 返回的是 `NanoHTTPD.Method` 枚举类型，而不是字符串。
原代码中使用 `"GET".equals(method)` 进行比较，永远返回 false。

## 修复内容
修改路由逻辑，使用 `Method.GET.equals(method)` 进行枚举比较。

## 技术细节
- `Method.GET.equals(method)` - 正确比较 GET 请求
- `Method.POST.equals(method)` - 正确比较 POST 请求
- `Method.DELETE.equals(method)` - 正确比较 DELETE 请求

## 关联任务
- #791551456664 - [Feature] 支持 /issues/{id}/relations.json 路径以管理任务阻塞关系