### PR TITLE
[Fix] 修复 createRelation Chunked Transfer Encoding 处理问题

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/api/JoyManApiService.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/api/JoyManApiService.java
@@ -134,6 +134,7 @@ public class JoyManApiService extends NanoHTTPD
 
     /**
      * 清理 Chunked Transfer Encoding 的数据
+     * 🔧 修复：正确处理 chunk size 和 end chunk
      */
     private String cleanChunkedData(String data)
     {
@@ -143,25 +144,23 @@ public class JoyManApiService extends NanoHTTPD
         }
         logUtils.d(TAG, "cleanChunkedData: === START ===");
         logUtils.d(TAG, "cleanChunkedData: Original data length: " + data.length());
+        logUtils.d(TAG, "cleanChunkedData: Original data (first 200 chars): " + data.substring(0, Math.min(200, data.length())));
 
-        String[] chunkedEndings = {
-            "\r\n0\r\n", "\r\n0\n", "\n0\r\n", "\n0\n", "\r\n0", "\n0"
-        };
-        String originalData = data;
-        for (String ending : chunkedEndings)
-        {
-            if (data.endsWith(ending))
-            {
-                logUtils.d(TAG, "cleanChunkedData: Removing chunked ending: " + ending);
-                data = data.substring(0, data.length() - ending.length());
-                break;
-            }
-        }
-
-        data = data.trim();
-        logUtils.d(TAG, "cleanChunkedData: Cleaned data length: " + data.length());
+        // 🔧 修复：使用正则表达式移除所有 chunk size 行和末尾的 end chunk
+        // Chunked Transfer Encoding 格式：<hex-size>\r\n<data>\r\n...0\r\n
+        // 移除所有形如 "42\r\n" 的 chunk size 行
+        String cleaned = data.replaceAll("^[0-9a-fA-F]+\\r\\n", "");
+        // 移除末尾的 end chunk "0\r\n" 或 "0\n"
+        cleaned = cleaned.replaceAll("\\r\\n0\\r\\n$", "");
+        cleaned = cleaned.replaceAll("\\n0\\n$", "");
+        cleaned = cleaned.replaceAll("\\r\\n0$", "");
+        cleaned = cleaned.replaceAll("\\n0$", "");
+        
+        cleaned = cleaned.trim();
+        logUtils.d(TAG, "cleanChunkedData: Cleaned data length: " + cleaned.length());
+        logUtils.d(TAG, "cleanChunkedData: Cleaned data (first 200 chars): " + cleaned.substring(0, Math.min(200, cleaned.length())));
         logUtils.d(TAG, "cleanChunkedData: === END ===");
-        return data;
+        return cleaned;
     }
 
     /**
@@ -1228,12 +1227,12 @@ public class JoyManApiService extends NanoHTTPD
         }
         
         // 🔧 调试：记录原始请求体
-        logUtils.d(TAG, "createRelation: Raw postData length=" + postData.length() + ", first 100 chars: " + postData.substring(0, Math.min(100, postData.length())));
+        logUtils.d(TAG, "createRelation: Raw postData length=" + postData.length() + ", first 200 chars: " + postData.substring(0, Math.min(200, postData.length())));
         
         postData = cleanChunkedData(postData);
         
         // 🔧 调试：记录清理后的请求体
-        logUtils.d(TAG, "createRelation: Cleaned postData length=" + postData.length() + ", first 100 chars: " + postData.substring(0, Math.min(100, postData.length())));
+        logUtils.d(TAG, "createRelation: Cleaned postData length=" + postData.length() + ", first 200 chars: " + postData.substring(0, Math.min(200, postData.length())));
         
         try
         {


### PR DESCRIPTION
## 问题描述
POST `/issues/{id}/relations.json` 返回 500 错误：
`java.lang.IllegalStateException: Not a JSON Object: 42`

## 根本原因
`cleanChunkedData()` 方法没有正确清理 Chunked Transfer Encoding 的数据。
原始数据包含 chunk size（如 `42\r\n`）和 end chunk（`\r\n0\r\n`），但该方法只移除了末尾的 end chunk，没有移除开头的 chunk size。

## 修复内容
1. 改进 `cleanChunkedData()` 方法，正确处理 Chunked Transfer Encoding
2. 移除开头的 chunk size 和 CRLF
3. 移除末尾的 end chunk 和 CRLF
4. 添加详细日志记录清理过程

## 技术细节
- Chunked Transfer Encoding 格式：`<hex-size>\r\n<data>\r\n...0\r\n`
- 需要移除所有 chunk size 行和末尾的 end chunk
- 使用正则表达式或手动解析来清理数据

## 关联任务
- #791551456664 - [Feature] 支持 /issues/{id}/relations.json 路径以管理任务阻塞关系