### PR TITLE
fix: 修复创建任务时 created_at 字段为 1970-01-01 的问题

### DIFF
--- a/app/src/main/java/com/stupidbeauty/joyman/api/ApiJsonConverter.java
+++ b/app/src/main/java/com/stupidbeauty/joyman/api/ApiJsonConverter.java
@@ -208,6 +208,11 @@ public class ApiJsonConverter {
             if (issueJson.has("parent_issue_id")) {
                 task.setParentId(issueJson.get("parent_issue_id").getAsLong());
             }
+            // 设置创建时间和更新时间（修复 1970-01-01 问题）
+            long now = System.currentTimeMillis();
+            task.setCreatedAt(now);
+            task.setUpdatedAt(now);
+
             
             logUtils.d(TAG, "jsonToTask: Created task from JSON: " + task.getTitle());
             


### PR DESCRIPTION
## 问题描述
通过 createRedmineTask 工具创建的任务，创建时间显示为 1970-01-01T00:00:00Z

## 修复内容
在 `ApiJsonConverter.java` 的 `jsonToTask` 方法中添加 createdAt 和 updatedAt 字段的设置：

```java
long now = System.currentTimeMillis();
task.setCreatedAt(now);
task.setUpdatedAt(now);
```

## 影响范围
- 仅影响通过 API 创建的新任务
- 不影响已存在的任务